### PR TITLE
Add OpenAPI spec and docs for spec origin

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -22,6 +22,7 @@ Reference
    :maxdepth: 3
 
    api-reference
+   openapi-spec
    contributing
    release-process
    changelog

--- a/docs/source/openapi-spec.rst
+++ b/docs/source/openapi-spec.rst
@@ -1,0 +1,6 @@
+OpenAPI Spec
+============
+
+The OpenAPI spec used to generate this library was created from the CoderPad API at ``https://api.interview.coderpad.io``.
+
+The spec was exported using Postman's export to OpenAPI feature.

--- a/openapi.json
+++ b/openapi.json
@@ -1,0 +1,4709 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "CoderPad Interview API",
+    "version": "1.0.0",
+    "description": "CoderPad provides a simple API for programmatically creating and managing interview pads. You can use the API to integrate these pads with your internal interview scheduling platform or to get a text dump of an interview after the fact.\n\nCoderPad provides a standard REST API that returns results in JSON format.\n\n# Authentication\n\nThe API uses a simple HTTP `Authorization` header to authenticate you. If you visit [your settings page](https://coderpad.io/settings), you’ll see your API key (this one is fake):\n\n**8af9a3412559d803707937250dc1569d**\n\nYou can then make requests against the API endpoint like so:\n\n``` plaintext\ncurl -H 'Authorization: Token token=\"8af9a3412559d803707937250dc1569d\"' \\\n  https://app.coderpad.io/api/pads\n\n ```\n\nThe authorization type for Interview is `Bearer token`:\n\n<img src=\"https://content.pstmn.io/20d5a999-b7d0-4a7d-a30c-23677d3a4f16/aW1hZ2UucG5n\" width=\"1160\" height=\"181\">\n\n# Errors\n\nThe API will always return a top-level JSON object, along with a status code to indicate success or failure. When successful, the API will return an HTTP 200, as well as `{ status: \"OK\" }`.\n\nWhen calls are unsuccessful, they return an appropriate HTTP code, as well as something like\n\n``` json\n{\n  \"status\": \"ERROR\",\n  \"message\": \"Invalid API key\"\n}\n\n ```\n\nThe following is a table of HTTP codes from errors that you can expect to see:\n\n| HTTP Code | Message | Description |\n| --- | --- | --- |\n| 200 |  | Everything’s good! |\n| 400 | Bad Request | You sent a malformed request, like a programming language we don’t yet support. |\n| 401 | Invalid API key | Your API key wasn’t tied to a valid account. |\n| 403 | Forbidden | You don’t have permission to access that resource. |\n| 404 | Resource not found | We couldn’t find that resource for you… It probably doesn’t exist. |\n| 429 | Over quota | You’ve exceeded the number of pads your plan allows in a month. |\n\n# Languages\n\nWhen a resource contains a `language` field, it’s value is one of a set list:\n\n- angular\n    \n- bash\n    \n- c\n    \n- clojure\n    \n- coffeescript\n    \n- cpp\n    \n- csharp\n    \n- django\n    \n- elixir\n    \n- erlang\n    \n- fsharp\n    \n- gin\n    \n- haskell\n    \n- html\n    \n- java\n    \n- javascript\n    \n- julia\n    \n- kotlin\n    \n- lua\n    \n- markdown\n    \n- node\n    \n- objc\n    \n- ocaml\n    \n- perl\n    \n- php\n    \n- plaintext\n    \n- postgresql\n    \n- python\n    \n- rails\n    \n- react\n    \n- ruby\n    \n- rust\n    \n- spring\n    \n- svelte\n    \n- swift\n    \n- tcl\n    \n- typescript\n    \n- vb\n    \n- vue"
+  },
+  "servers": [
+    {
+      "url": "{{baseUrl}}"
+    }
+  ],
+  "paths": {
+    "/api/pads/": {
+      "get": {
+        "summary": "Retrieve a list of pads",
+        "responses": {
+          "200": {
+            "description": "Successful request",
+            "headers": {
+              "Date": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Wed, 02 Aug 2023 12:25:54 GMT"
+              },
+              "Transfer-Encoding": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "chunked"
+              },
+              "Connection": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "keep-alive"
+              },
+              "x-frame-options": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "SAMEORIGIN"
+              },
+              "x-xss-protection": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "1; mode=block"
+              },
+              "x-content-type-options": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "nosniff"
+              },
+              "x-download-options": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "noopen"
+              },
+              "x-permitted-cross-domain-policies": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "none"
+              },
+              "referrer-policy": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "strict-origin-when-cross-origin"
+              },
+              "x-ua-compatible": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "IE=edge"
+              },
+              "strict-transport-security": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "max-age=31536000; includeSubDomains; preload"
+              },
+              "x-robots-tag": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "none"
+              },
+              "vary": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Accept-Encoding,Origin"
+              },
+              "Content-Encoding": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "identity"
+              },
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "max-age=0"
+              },
+              "content-security-policy": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "default-src 'self' https: blob:; connect-src 'self' ws: https: wss: file: https://edge.fullstory.com https://rs.fullstory.com https://sentry.io; img-src 'self' https: data: http: blob: https://www.googletagmanager.com https://rs.fullstory.com; object-src 'none'; script-src 'self' https: https://*.firebaseio.com https://www.googletagmanager.com https://edge.fullstory.com https://rs.fullstory.com https://js.hs-analytics.net https://www.google-analytics.com https://connect.facebook.net https://widget.intercom.io 'unsafe-inline' 'unsafe-eval'; worker-src 'self' https: blob:; style-src 'self' https: blob: 'unsafe-inline' 'unsafe-eval'; media-src 'self' https: data: blob:; font-src 'self' https: data: chrome-extension moz-extension https://fonts.gstatic.com http://themes.googleusercontent.com; report-uri /csp-report"
+              },
+              "x-request-id": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "a870bd9e-b7dd-42a2-87fb-4fedc7195002"
+              },
+              "x-runtime": {
+                "schema": {
+                  "type": "number"
+                },
+                "example": "0.540921"
+              },
+              "via": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "1.1 vegur"
+              },
+              "cf-cache-status": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "DYNAMIC"
+              },
+              "report-to": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=dBgsU%2FH8G8vIBCnfhUEUncVkHtUn%2FBFFDOrn8V%2BvSgMBV%2FYzLfercockP60UgokL9gBoIdObFfGqLYNuc%2F7Evwby8JGRg1MywyfBMZA3aQUeoAEfqFDda5kXX44Pnc0qkQ%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              },
+              "nel": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+              },
+              "expires": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Wed, 02 Aug 2023 12:25:53 GMT"
+              },
+              "access-control-allow-origin": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "https://coderpad.io"
+              },
+              "Server": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "cloudflare"
+              },
+              "CF-RAY": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "7f064e5eeadf8256-IAD"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string"
+                    },
+                    "pads": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "state": {
+                            "type": "string"
+                          },
+                          "owner_email": {
+                            "type": "string",
+                            "format": "email"
+                          },
+                          "language": {
+                            "type": "string"
+                          },
+                          "private": {
+                            "type": "boolean"
+                          },
+                          "execution_enabled": {
+                            "type": "boolean"
+                          },
+                          "contents": {
+                            "type": "null"
+                          },
+                          "participants": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "events": {
+                            "type": "string",
+                            "format": "uri"
+                          },
+                          "notes": {
+                            "type": "null"
+                          },
+                          "created_at": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "updated_at": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "ended_at": {
+                            "type": "null"
+                          },
+                          "url": {
+                            "type": "string",
+                            "format": "uri"
+                          },
+                          "playback": {
+                            "type": "string",
+                            "format": "uri"
+                          },
+                          "history": {
+                            "type": "string",
+                            "format": "uri"
+                          },
+                          "drawing": {
+                            "type": "null"
+                          },
+                          "type": {
+                            "type": "string"
+                          },
+                          "question_ids": {
+                            "type": "array"
+                          },
+                          "pad_environment_ids": {
+                            "type": "array",
+                            "items": {
+                              "type": "integer"
+                            }
+                          },
+                          "active_environment_id": {
+                            "type": "integer"
+                          },
+                          "team": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "next_page": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "total": {
+                      "type": "integer"
+                    }
+                  }
+                },
+                "example": {
+                  "status": "OK",
+                  "pads": [
+                    {
+                      "id": "AB12345",
+                      "title": "Untitled Pad - AB12345",
+                      "state": "pending",
+                      "owner_email": "some.person@coderpad.io",
+                      "language": "go",
+                      "private": true,
+                      "execution_enabled": true,
+                      "contents": null,
+                      "participants": ["some.person"],
+                      "events": "https://app.coderpad.io/api/pads/AB12345/events",
+                      "notes": null,
+                      "created_at": "2023-08-02T12:22:30Z",
+                      "updated_at": "2023-08-02T12:24:16Z",
+                      "ended_at": null,
+                      "url": "https://coderpad.io/AB12345",
+                      "playback": "https://coderpad.io/AB12345/playback",
+                      "history": "https://coderpad-8.firebaseio.com/AB12345/history.json",
+                      "drawing": null,
+                      "type": "live",
+                      "question_ids": [],
+                      "pad_environment_ids": [5467777],
+                      "active_environment_id": 5467777,
+                      "team": {
+                        "id": "68264172-5a54-4ac3-962b-cb8d1ad15d05",
+                        "name": "Main Team"
+                      }
+                    },
+                    {
+                      "id": "CGH8767",
+                      "title": "Untitled Pad - CGH8767",
+                      "state": "pending",
+                      "owner_email": "person.some@coderpad.io",
+                      "language": "postgresql",
+                      "private": true,
+                      "execution_enabled": true,
+                      "contents": null,
+                      "participants": ["person.some"],
+                      "events": "https://app.coderpad.io/api/pads/CGH8767/events",
+                      "notes": null,
+                      "created_at": "2023-08-02T10:27:51Z",
+                      "updated_at": "2023-08-02T10:29:49Z",
+                      "ended_at": null,
+                      "url": "https://coderpad.io/CGH8767",
+                      "playback": "https://coderpad.io/CGH8767/playback",
+                      "history": "https://coderpad-6.firebaseio.com/CGH8767/history.json",
+                      "drawing": null,
+                      "type": "live",
+                      "question_ids": [],
+                      "pad_environment_ids": [1234567, 7654321],
+                      "active_environment_id": 7654321,
+                      "team": {
+                        "id": "4a0f61a3-3013-49f5-9eb7-9f83712a49bf",
+                        "name": "Second Team"
+                      }
+                    },
+                    {
+                      "id": "12PQRTS",
+                      "title": "Untitled Pad - 12PQRTS",
+                      "state": "pending",
+                      "owner_email": "robert.coder@coderpad.io",
+                      "language": "ruby",
+                      "private": true,
+                      "execution_enabled": true,
+                      "contents": null,
+                      "participants": ["robert.coder"],
+                      "events": "https://app.coderpad.io/api/pads/12PQRTS/events",
+                      "notes": "This is a good candidaite",
+                      "created_at": "2023-08-02T09:25:49Z",
+                      "updated_at": "2023-08-02T09:28:02Z",
+                      "ended_at": null,
+                      "url": "https://coderpad.io/12PQRTS",
+                      "playback": "https://coderpad.io/12PQRTS/playback",
+                      "history": "https://coderpad-7.firebaseio.com/12PQRTS/history.json",
+                      "drawing": null,
+                      "type": "live",
+                      "question_ids": [54321],
+                      "pad_environment_ids": [1234567, 1234568, 1234569],
+                      "active_environment_id": 1234569,
+                      "team": {
+                        "id": "68264172-5a54-4ac3-962b-cb8d1ad15d05",
+                        "name": "Main Team"
+                      }
+                    }
+                  ],
+                  "next_page": "https://app.coderpad.io/api/pads?page=2",
+                  "total": 1234
+                }
+              }
+            }
+          }
+        },
+        "tags": ["v1.0", "Pads"],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "description": "Fetch a list of all of your pads. Returns everything that an individual _Get pads by id_ request does. The only caveat is that the values of fields in the index view are not guaranteed to be 100% real-time. Generally, they should be no more than a minute behind, but if you absolutely require the latest value in a pad, please use the individual _Get pads by id_ endpoint.\n\n```\ncurl \\\n  -H 'Authorization: Token token=\"8af9a3412559d803707937250dc1569d\"' \\\n  <a class=&#x27;preserveHtml&#x27; class=&#x27;preserveHtml&#x27; target=\"_blank\"  rel=\"noreferrer noopener\" href=\"https://app.coderpad.io/api/pads?sort=updated_at,descThis\">https://app.coderpad.io/api/pads?sort=updated_at,desc</a>\n\n ```\n\nThis API endpoint takes an optional `sort` parameter, which allows you to sort by either the `created_at` or `updated_at` fields on your pads. Adding a comma will allow you to change the sort direction, which is `desc` by default. For example, to sort your pads by `updated_at` from oldest to newest, specify `updated_at,asc`.\n\nIf no `sort` parameter is provided, `created_at,desc` is assumed.\n\nThe method also returns paginated results - no more than 50 per request. If you want more, follow the `next_page` or `prev_page` urls if present. The API also returns a `total` count to give you a sense of how many pads you have created.\n\n``` json\n{\n  \"status\": \"OK\",\n  \"pads\": [\n    // ... your pads, with the same data format as in `show`\n  ],\n  \"next_page\": \"https://app.coderpad.io/api/pads?sort=updated_at,desc&page=2\",\n  \"total\": 420\n}\n\n ```"
+      },
+      "post": {
+        "summary": "Create a pad",
+        "responses": {
+          "200": {
+            "description": "Successful request",
+            "headers": {
+              "Date": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Fri, 11 Aug 2023 18:50:13 GMT"
+              },
+              "Transfer-Encoding": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "chunked"
+              },
+              "Connection": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "keep-alive"
+              },
+              "X-Frame-Options": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "SAMEORIGIN"
+              },
+              "X-Xss-Protection": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "1; mode=block"
+              },
+              "X-Content-Type-Options": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "nosniff"
+              },
+              "X-Download-Options": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "noopen"
+              },
+              "X-Permitted-Cross-Domain-Policies": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "none"
+              },
+              "Referrer-Policy": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "strict-origin-when-cross-origin"
+              },
+              "X-Ua-Compatible": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "IE=edge"
+              },
+              "Strict-Transport-Security": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "max-age=31536000; includeSubDomains; preload"
+              },
+              "X-Robots-Tag": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "none"
+              },
+              "Vary": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Accept-Encoding, Origin"
+              },
+              "Etag": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "W/\"4efaf72064335054dacafa402ea1d458\""
+              },
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "max-age=0, private, must-revalidate"
+              },
+              "Content-Security-Policy": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "default-src 'self' https: blob:; connect-src 'self' ws: https: wss: file: https://edge.fullstory.com https://rs.fullstory.com https://sentry.io; img-src 'self' https: data: http: blob: https://www.googletagmanager.com https://rs.fullstory.com; object-src 'none'; script-src 'self' https: https://*.firebaseio.com https://www.googletagmanager.com https://edge.fullstory.com https://rs.fullstory.com https://js.hs-analytics.net https://www.google-analytics.com https://connect.facebook.net https://widget.intercom.io 'unsafe-inline' 'unsafe-eval'; worker-src 'self' https: blob:; style-src 'self' https: blob: 'unsafe-inline' 'unsafe-eval'; media-src 'self' https: data: blob:; font-src 'self' https: data: chrome-extension moz-extension https://fonts.gstatic.com http://themes.googleusercontent.com; report-uri /csp-report"
+              },
+              "Set-Cookie": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "_coderpad_rails_session_3=a9085f65b34eb3a378bf0fb7a61b5035; domain=.coderpad.io; path=/; secure; HttpOnly; SameSite=Lax"
+              },
+              "X-Request-Id": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "44fd55d4-da5d-484d-970b-ed7d5878794f"
+              },
+              "X-Runtime": {
+                "schema": {
+                  "type": "number"
+                },
+                "example": "0.556391"
+              },
+              "Via": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "1.1 vegur"
+              },
+              "CF-Cache-Status": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "DYNAMIC"
+              },
+              "Report-To": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=zt6PjBlxIxBLyn%2BsA2J1qk94yQmafkd7KS8mGl2S%2FCPR9nOAsIzwd7S%2F3JUi0c48AK2nnNYbjXq5WXAf4lLspnHkgRkixELpcVfyBpLbdTnQPRiYIR09G028FpRWsw9%2FTQ%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              },
+              "NEL": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+              },
+              "Server": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "cloudflare"
+              },
+              "CF-RAY": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "7f52a9b49c142034-IAD"
+              },
+              "Content-Encoding": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "br"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "state": {
+                      "type": "string"
+                    },
+                    "owner_email": {
+                      "type": "string",
+                      "format": "email"
+                    },
+                    "language": {
+                      "type": "string"
+                    },
+                    "private": {
+                      "type": "boolean"
+                    },
+                    "execution_enabled": {
+                      "type": "boolean"
+                    },
+                    "contents": {
+                      "type": "null"
+                    },
+                    "participants": {
+                      "type": "array"
+                    },
+                    "events": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "notes": {
+                      "type": "null"
+                    },
+                    "created_at": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "updated_at": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "ended_at": {
+                      "type": "null"
+                    },
+                    "url": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "playback": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "history": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "drawing": {
+                      "type": "null"
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "question_ids": {
+                      "type": "array"
+                    },
+                    "pad_environment_ids": {
+                      "type": "array",
+                      "items": {
+                        "type": "integer"
+                      }
+                    },
+                    "active_environment_id": {
+                      "type": "null"
+                    },
+                    "team": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "status": "OK",
+                  "id": "ABC1234",
+                  "title": "Untitled Pad - ABC1234",
+                  "state": "pending",
+                  "owner_email": "ken@coderpad.io",
+                  "language": "javascript",
+                  "private": true,
+                  "execution_enabled": true,
+                  "contents": null,
+                  "participants": [],
+                  "events": "https://app.coderpad.io/api/pads/ABC1234/events",
+                  "notes": null,
+                  "created_at": "2023-08-11T18:50:12Z",
+                  "updated_at": "2023-08-11T18:50:12Z",
+                  "ended_at": null,
+                  "url": "https://coderpad.io/ABC1234",
+                  "playback": "https://coderpad.io/ABC1234/playback",
+                  "history": "https://coderpad-5.firebaseio.com/ABC1234/history.json",
+                  "drawing": null,
+                  "type": "live",
+                  "question_ids": [],
+                  "pad_environment_ids": [5018867],
+                  "active_environment_id": null,
+                  "team": {
+                    "id": "68264172-5a54-4ac3-962b-cb8d1ad15d05",
+                    "name": "Main Team"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": ["v1.0", "Pads"],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "description": "Create a new pad. You can set some initial conditions as well.\n\n```\ncurl \\\n  --data title=\"Rob Zombie's Interview\" \\\n  --data language=\"ruby\" \\\n  --data contents=\"print 'Hello, World'\" \\\n  --data notes=\"Your private notes\" \\\n  -H 'Authorization: Token token=\"8af9a3412559d803707937250dc1569d\"' \\\n  https://app.coderpad.io/api/pads\n\n ```\n\nreturns\n\n``` json\n{\n  \"status\": \"OK\",\n  \"id\": \"AFQ2K9A3\",\n  \"title\": \"Rob Zombie's Interview\",\n  \"owner_email\": \"fbueller@gmail.com\",\n  \"language\": \"ruby\",\n  \"participants\": [\"vincent\"],\n  \"contents\": \"print 'Hello, World'\",\n  \"notes\": \"Your private notes\",\n  \"events\": \"https://app.coderpad.io/api/pads/AFQ2K9A3/events\",\n  \"private\": false,\n  \"execution_enabled\": true,\n  \"created_at\": \"2014-11-14T03:02:45Z\",\n  \"updated_at\": \"2014-11-14T03:02:45Z\",\n  \"ended_at\": null,\n  \"url\": \"https://coderpad.io/AFQ2K9A3\",\n  \"playback\": \"https://coderpad.io/AFQ2K9A3/playback\",\n  \"history\": \"https://coderpad.firebaseio.com/AFQ2K9A3/history.json\",\n  \"drawing\": null,\n  \"pad_environment_ids\": [\n    1234567,\n    7654321\n  ],\n  \"active_environment_id\": 1234567,\n  \"team\": {\n    \"id\": \"68264172-5a54-4ac3-962b-cb8d1ad15d05\",\n    \"name\": \"Main Team\"\n  }\n}\n\n ```\n\nThis method can return a quota exceeded error if you are over your used pad limit for the month."
+      },
+      "put": {
+        "summary": "Modify a pad",
+        "responses": {
+          "200": {
+            "description": "Successful request",
+            "headers": {
+              "Date": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Wed, 02 Aug 2023 14:20:57 GMT"
+              },
+              "Transfer-Encoding": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "chunked"
+              },
+              "Connection": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "keep-alive"
+              },
+              "X-Frame-Options": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "SAMEORIGIN"
+              },
+              "X-Xss-Protection": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "1; mode=block"
+              },
+              "X-Content-Type-Options": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "nosniff"
+              },
+              "X-Download-Options": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "noopen"
+              },
+              "X-Permitted-Cross-Domain-Policies": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "none"
+              },
+              "Referrer-Policy": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "strict-origin-when-cross-origin"
+              },
+              "X-Ua-Compatible": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "IE=edge"
+              },
+              "Strict-Transport-Security": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "max-age=63072000; includeSubDomains"
+              },
+              "X-Robots-Tag": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "none"
+              },
+              "Vary": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Accept-Encoding, Origin"
+              },
+              "Etag": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "W/\"f91924ee263f0f16771114170bca8e1e\""
+              },
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "max-age=0, private, must-revalidate"
+              },
+              "Content-Security-Policy": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "default-src 'self' https: blob:; connect-src 'self' ws: https: wss: file: https://edge.fullstory.com https://rs.fullstory.com https://sentry.io; img-src 'self' https: data: http: blob: https://www.googletagmanager.com https://rs.fullstory.com; object-src 'none'; script-src 'self' https: https://*.firebaseio.com https://www.googletagmanager.com https://edge.fullstory.com https://rs.fullstory.com https://js.hs-analytics.net https://www.google-analytics.com https://connect.facebook.net https://widget.intercom.io 'unsafe-inline' 'unsafe-eval'; worker-src 'self' https: blob:; style-src 'self' https: blob: 'unsafe-inline' 'unsafe-eval'; media-src 'self' https: data: blob:; font-src 'self' https: data: chrome-extension moz-extension https://fonts.gstatic.com http://themes.googleusercontent.com; report-uri /csp-report"
+              },
+              "Set-Cookie": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "_coderpad_rails_session_3=8a7366cd51b2d7268b8deef226174d91; domain=coderpad-staging.io; path=/; HttpOnly; SameSite=Lax; secure"
+              },
+              "X-Request-Id": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "9bf3bbfc-e45a-4304-97d8-51673f9f65db"
+              },
+              "X-Runtime": {
+                "schema": {
+                  "type": "number"
+                },
+                "example": "0.034633"
+              },
+              "Via": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "1.1 vegur"
+              },
+              "CF-Cache-Status": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "DYNAMIC"
+              },
+              "Report-To": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=%2Fth%2FuClORs8iRwWlGFysbAXd3uTobUJPZbFyHf%2FWIS22I9VjgETLjgDSLjqf%2FsEF5AKoIM5GceuVZD2XRtQo8CigJYpMcjPVLJXR9Eed0LKf67nhNXNZ68vx4ZPIr6bwh%2FNspgkvpX2c\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              },
+              "NEL": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+              },
+              "Server": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "cloudflare"
+              },
+              "CF-RAY": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "7f06f6e95b0c58cc-IAD"
+              },
+              "Content-Encoding": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "br"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "example": {
+                  "status": "OK"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["v1.0", "Pads"],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "description": "Modifies an existing pad. You can specify any of the valid parameters you used to create the pad.\n\nYou may also use this endpoint to end the interview, by setting the `ended` attribute to `true`, or delete the interview, by setting the `deleted` attribute to `true`. Values other than `true` will be ignored.\n\n```\ncurl \\\n  -X PUT --data title=\"Interview with Greg\" \\\n  -H 'Authorization: Token token=\"8af9a3412559d803707937250dc1569d\"' \\\n  https://app.coderpad.io/api/pads/AFQ2K9A3\n\n ```\n\nPlease note that resetting the contents in the middle of an ongoing interview session will probably break something. It will also destroy the history for that pad. Use with caution."
+      }
+    },
+    "/api/pads/{id}": {
+      "get": {
+        "summary": "Retrieve a pad by id",
+        "responses": {
+          "200": {
+            "description": "Successful request",
+            "headers": {
+              "Date": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Wed, 02 Aug 2023 10:55:16 GMT"
+              },
+              "Transfer-Encoding": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "chunked"
+              },
+              "Connection": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "keep-alive"
+              },
+              "x-frame-options": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "SAMEORIGIN"
+              },
+              "x-xss-protection": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "1; mode=block"
+              },
+              "x-content-type-options": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "nosniff"
+              },
+              "x-download-options": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "noopen"
+              },
+              "x-permitted-cross-domain-policies": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "none"
+              },
+              "referrer-policy": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "strict-origin-when-cross-origin"
+              },
+              "x-ua-compatible": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "IE=edge"
+              },
+              "strict-transport-security": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "max-age=31536000; includeSubDomains; preload"
+              },
+              "x-robots-tag": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "none"
+              },
+              "vary": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Accept-Encoding,Origin"
+              },
+              "Content-Encoding": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "identity"
+              },
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "max-age=0"
+              },
+              "content-security-policy": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "default-src 'self' https: blob:; connect-src 'self' ws: https: wss: file: https://edge.fullstory.com https://rs.fullstory.com https://sentry.io; img-src 'self' https: data: http: blob: https://www.googletagmanager.com https://rs.fullstory.com; object-src 'none'; script-src 'self' https: https://*.firebaseio.com https://www.googletagmanager.com https://edge.fullstory.com https://rs.fullstory.com https://js.hs-analytics.net https://www.google-analytics.com https://connect.facebook.net https://widget.intercom.io 'unsafe-inline' 'unsafe-eval'; worker-src 'self' https: blob:; style-src 'self' https: blob: 'unsafe-inline' 'unsafe-eval'; media-src 'self' https: data: blob:; font-src 'self' https: data: chrome-extension moz-extension https://fonts.gstatic.com http://themes.googleusercontent.com; report-uri /csp-report"
+              },
+              "x-request-id": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "ae34cb92-ac14-4276-89b0-a0798769b1c6"
+              },
+              "x-runtime": {
+                "schema": {
+                  "type": "number"
+                },
+                "example": "0.731418"
+              },
+              "via": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "1.1 vegur"
+              },
+              "cf-cache-status": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "DYNAMIC"
+              },
+              "report-to": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=6xkSncUifzPWJqjH5P8RitR783qmrfdiNi7AtrVLRbTcy9ZNkF%2BJQUnpkNB4wD7TX4ExDlECPP01%2BbsREBHMUgyFJRclmYq%2F4jqiG3%2BTsFcTKwca29kVSVMgoEYhDn82yg%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              },
+              "nel": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+              },
+              "expires": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Wed, 02 Aug 2023 10:55:15 GMT"
+              },
+              "access-control-allow-origin": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "https://coderpad.io"
+              },
+              "Server": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "cloudflare"
+              },
+              "CF-RAY": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "7f05c997fae78274-IAD"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "state": {
+                      "type": "string"
+                    },
+                    "owner_email": {
+                      "type": "string",
+                      "format": "email"
+                    },
+                    "language": {
+                      "type": "string"
+                    },
+                    "private": {
+                      "type": "boolean"
+                    },
+                    "execution_enabled": {
+                      "type": "boolean"
+                    },
+                    "contents": {
+                      "type": "null"
+                    },
+                    "participants": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "events": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "notes": {
+                      "type": "null"
+                    },
+                    "created_at": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "updated_at": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "ended_at": {
+                      "type": "null"
+                    },
+                    "url": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "playback": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "drawing": {
+                      "type": "null"
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "question_ids": {
+                      "type": "array"
+                    },
+                    "pad_environment_ids": {
+                      "type": "array",
+                      "items": {
+                        "type": "integer"
+                      }
+                    },
+                    "active_environment_id": {
+                      "type": "integer"
+                    },
+                    "team": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "status": "OK",
+                  "id": "983SDkjdsh",
+                  "title": "Untitled Pad - 983SDkjdsh",
+                  "state": "pending",
+                  "owner_email": "some.person@coderpad.io",
+                  "language": "postgresql",
+                  "private": true,
+                  "execution_enabled": true,
+                  "contents": null,
+                  "participants": ["some.person"],
+                  "events": "https://app.coderpad.io/api/pads/983SDkjdsh/events",
+                  "notes": null,
+                  "created_at": "2023-08-02T10:27:51Z",
+                  "updated_at": "2023-08-02T10:29:49Z",
+                  "ended_at": null,
+                  "url": "https://coderpad.io/983SDkjdsh",
+                  "playback": "https://coderpad.io/983SDkjdsh/playback",
+                  "drawing": null,
+                  "type": "live",
+                  "question_ids": [],
+                  "pad_environment_ids": [1234567, 7654321],
+                  "active_environment_id": 1234567,
+                  "team": {
+                    "id": "68264172-5a54-4ac3-962b-cb8d1ad15d05",
+                    "name": "Main Team"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": ["v1.0", "Pads"],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "description": "Returns detail about a particular pad. Doing a straightforward curl like so:\n\n```\ncurl \\\n  -H 'Authorization: Token token=\"c\"' \\\n  https://app.coderpad.io/api/pads/DM32JWG2\n\n ```\n\nyields:\n\n``` json\n{\n  status: \"OK\",\n  id: \"DM32JWG2\",\n  title: \"Ruby Test\",\n  owner_email: \"fbueller@gmail.com\",\n  language: \"ruby\",\n  participants: [\n    \"vincent\",\n    \"Guest 405\"\n  ],\n  contents: \"5.times do\\n  puts 'Hello, World!'\\nend\\n\",\n  notes: \"Greg was a *very* gregarious candidate, whom...\"\n  events: \"https://app.coderpad.io/api/pads/DM32JWG2/events\",\n  private: false,\n  execution_enabled: true,\n  created_at: \"2014-11-14T03:02:45Z\",\n  updated_at: \"2014-11-14T03:06:39Z\",\n  ended_at:   \"2014-11-14T03:06:39Z\",\n  url: \"https://coderpad.io/DM32JWG2\",\n  playback: \"https://coderpad.io/DM32JWG2/playback\",\n  drawing: \"https://storage.googleapis.com/...\",\n  pad_environment_ids: [\n    1234567,\n    7654321\n  ],\n  active_environment_id: 1234567,\n  team: {\n    id: \"68264172-5a54-4ac3-962b-cb8d1ad15d05\",\n    name: \"Main Team\"\n  }\n}\n\n ```\n\nFields returned:\n\n| **Field** | **Description** |\n| --- | --- |\n| id | `string` Primary key for the object. Use this to query or modify this resource later. |\n| title | `string` User-assigned title of the pad. |\n| owner_email | `string` Email address of the owner of the pad. Will usually just be your email! |\n| language | `string` Chosen language for the pad. [Full list is here](#Languages). |\n| participants | `array` The self-reported names of the participants. |\n| contents | `string` Latest contents of the pad editor. Updates in real-time. For pads that support multiple environments, this will be nil, and you can get the contents for each environment at the pad_environments endpoint. |\n| notes | `string` Markdown-formatted notes taken by the interviewer. |\n| events | `string` A link to an API endpoint containing a log of events created by users during the pad session. [See <i>Get a list of pad events</i> below.](#c1a6a910-8b73-4f56-a929-3947c571af35). |\n| private | `boolean` Whether the pad is viewable by guests, ie whether the [waiting room](https://coderpad.io/resources/docs/interview/pads/settings/#waiting-room) is enabled or not. Private pads will essentially 404 unless you are authorized to view the pad. Defaults to `false`. |\n| execution_enabled | `boolean` Whether to allow running code in this pad. When set to false, this hides the right-hand side of the pad interface. Defaults to `true`. |\n| created_at | `datetime` When the pad was created, in UTC ISO 8601, like `2015-01-30T00:22:55.520Z`. |\n| updated_at | `datetime` Similarly, when the pad was last updated. |\n| ended_at | `datetime` The time when the interview was ended. `null` if it has not ended yet. |\n| url | `string` Convenience field to link human users to the editing interface for this pad. |\n| playback | `string` Convenience field to link human users to the playback interface for this pad. |\n| drawing | `string` A URL where you can download the final state of a drawing made with Drawing Mode. These URLs are signed URLs that are valid for 5 minutes, after which you will need to make another request to our API to get a fresh signed URL. |\n| pad_environment_ids | `array` An array of IDs which can be used to fetch the environment details from the pad_environments endpoint. [See <i>Get pad environment information</i> below](#4458345f-f2a1-44b1-921b-d79445cbe365). |\n| active_environment_id | `string` The ID of the currently active environment. |\n| question_ids | `string` An array of question Ids for questions used in the pad. |\n| team | `{ id: string, name: string }` An object describing the team the pad is linked to. |\n\nAll values returned by this request are real-time as of the moment you request them."
+      },
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Id of the pad.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "/api/pads/{id}/events": {
+      "get": {
+        "summary": "Retrieve a list of pad events",
+        "responses": {
+          "200": {
+            "description": "Succesful request",
+            "headers": {
+              "Date": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Wed, 02 Aug 2023 11:24:33 GMT"
+              },
+              "Transfer-Encoding": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "chunked"
+              },
+              "Connection": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "keep-alive"
+              },
+              "x-frame-options": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "SAMEORIGIN"
+              },
+              "x-xss-protection": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "1; mode=block"
+              },
+              "x-content-type-options": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "nosniff"
+              },
+              "x-download-options": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "noopen"
+              },
+              "x-permitted-cross-domain-policies": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "none"
+              },
+              "referrer-policy": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "strict-origin-when-cross-origin"
+              },
+              "x-ua-compatible": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "IE=edge"
+              },
+              "strict-transport-security": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "max-age=31536000; includeSubDomains; preload"
+              },
+              "x-robots-tag": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "none"
+              },
+              "vary": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Accept-Encoding,Origin"
+              },
+              "Content-Encoding": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "identity"
+              },
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "max-age=0"
+              },
+              "content-security-policy": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "default-src 'self' https: blob:; connect-src 'self' ws: https: wss: file: https://edge.fullstory.com https://rs.fullstory.com https://sentry.io; img-src 'self' https: data: http: blob: https://www.googletagmanager.com https://rs.fullstory.com; object-src 'none'; script-src 'self' https: https://*.firebaseio.com https://www.googletagmanager.com https://edge.fullstory.com https://rs.fullstory.com https://js.hs-analytics.net https://www.google-analytics.com https://connect.facebook.net https://widget.intercom.io 'unsafe-inline' 'unsafe-eval'; worker-src 'self' https: blob:; style-src 'self' https: blob: 'unsafe-inline' 'unsafe-eval'; media-src 'self' https: data: blob:; font-src 'self' https: data: chrome-extension moz-extension https://fonts.gstatic.com http://themes.googleusercontent.com; report-uri /csp-report"
+              },
+              "x-request-id": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "4456febe-b53f-4d5a-8307-709767616dea"
+              },
+              "x-runtime": {
+                "schema": {
+                  "type": "number"
+                },
+                "example": "0.105463"
+              },
+              "via": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "1.1 vegur"
+              },
+              "cf-cache-status": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "DYNAMIC"
+              },
+              "report-to": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=T3Y3f6pxhlqqbX%2FahZuNiQ0FOX%2B312MEVMmtEAgS2BAOJAICwqWnGlsdiDooMqu%2FcY9GhIKIaWGZbYHvzMNVNTG0AeOTzrsdiLGvdDdc18zMZxxpD533yHZzeR4%2FMPEtPA%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              },
+              "nel": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+              },
+              "expires": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Wed, 02 Aug 2023 11:24:32 GMT"
+              },
+              "access-control-allow-origin": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "https://coderpad.io"
+              },
+              "Server": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "cloudflare"
+              },
+              "CF-RAY": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "7f05f47e18571fe3-IAD"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string"
+                    },
+                    "events": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "message": {
+                            "type": "string",
+                            "format": "style"
+                          },
+                          "kind": {
+                            "type": "string"
+                          },
+                          "metadata": {
+                            "type": "null"
+                          },
+                          "user_name": {
+                            "type": "null"
+                          },
+                          "user_email": {
+                            "type": "null"
+                          },
+                          "created_at": {
+                            "type": "string",
+                            "format": "date-time"
+                          }
+                        }
+                      }
+                    },
+                    "total": {
+                      "type": "integer"
+                    }
+                  }
+                },
+                "example": {
+                  "status": "OK",
+                  "events": [
+                    {
+                      "message": "2023-06-28T17:16:53Z: Sidekiq auto_ended the interview",
+                      "kind": "auto_ended",
+                      "metadata": null,
+                      "user_name": null,
+                      "user_email": null,
+                      "created_at": "2023-06-28T17:16:53Z"
+                    },
+                    {
+                      "message": "2023-06-21T17:18:06Z: Alan Turing left the pad",
+                      "kind": "left",
+                      "metadata": null,
+                      "user_name": "Alan Turing",
+                      "user_email": null,
+                      "created_at": "2023-06-21T17:18:06Z"
+                    },
+                    {
+                      "message": "2023-06-21T17:16:49Z: Someone started the interview",
+                      "kind": "started",
+                      "metadata": null,
+                      "user_name": null,
+                      "user_email": null,
+                      "created_at": "2023-06-21T17:16:49Z"
+                    },
+                    {
+                      "message": "2023-06-21T17:16:41Z: Alan Turing ran javascript code",
+                      "kind": "ran",
+                      "metadata": "javascript",
+                      "user_name": "Alan Turing",
+                      "user_email": null,
+                      "created_at": "2023-06-21T17:16:41Z"
+                    },
+                    {
+                      "message": "2023-06-21T17:15:23Z: Alan Turing joined the pad",
+                      "kind": "joined",
+                      "metadata": null,
+                      "user_name": "Alan Turing",
+                      "user_email": "ken+test@coderpad.io",
+                      "created_at": "2023-06-21T17:15:23Z"
+                    },
+                    {
+                      "message": "2023-06-21T17:13:28Z: ken joined the pad",
+                      "kind": "joined",
+                      "metadata": null,
+                      "user_name": "ken",
+                      "user_email": "ken@coderpad.io",
+                      "created_at": "2023-06-21T17:13:28Z"
+                    },
+                    {
+                      "message": "2023-06-21T17:13:26Z: ken added_question ID 123456",
+                      "kind": "added_question",
+                      "metadata": "123456",
+                      "user_name": "ken",
+                      "user_email": "ken@coderpad.io",
+                      "created_at": "2023-06-21T17:13:26Z"
+                    }
+                  ],
+                  "total": 7
+                }
+              }
+            }
+          }
+        },
+        "tags": ["v1.0", "Pads"],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "description": "Returns detail about important **events** that transpired throughout the lifetime of the pad. It is represented as an array of objects with the following fields:\n\n| Field | Description |\n| --- | --- |\n| message | `string` The human-readable string version of the event. |\n| kind | `string`Can be one of:  <br>  <br>\\- `joined`: when a user browses to a pad  <br>\\- `left`: when a user closes the browser tab  <br>\\- `ran`: when a user executes code  <br>\\- `enabled`: when the pad owner enables code execution  <br>\\- `disabled`: when the pad owner disables code execution  <br>\\- `ended`: when the pad owner ends the interview |\n| metadata | `string` Additional information associated with the event. In the case of a `ran` event, this will be the programming language run, for `joined` this can be `invisible` if a user joins in spectator mode. |\n| user_name | `string` Name of the user performing the event, will always be present. |\n| user_email | `string` If the user is logged in, this will be their email at the time of the event. |\n| created_at | `datetime` When the event occurred. |\n\nThis endpoint supports sorting and pagination similar to the `/api/pads/` endpoint."
+      },
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "/api/pad_environments/{id}": {
+      "get": {
+        "summary": "Retrieve pad environment information",
+        "responses": {
+          "200": {
+            "description": "Successful request",
+            "headers": {
+              "Date": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Wed, 02 Aug 2023 16:10:31 GMT"
+              },
+              "Transfer-Encoding": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "chunked"
+              },
+              "Connection": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "keep-alive"
+              },
+              "X-Frame-Options": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "SAMEORIGIN"
+              },
+              "X-Xss-Protection": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "1; mode=block"
+              },
+              "X-Content-Type-Options": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "nosniff"
+              },
+              "X-Download-Options": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "noopen"
+              },
+              "X-Permitted-Cross-Domain-Policies": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "none"
+              },
+              "Referrer-Policy": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "strict-origin-when-cross-origin"
+              },
+              "X-Ua-Compatible": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "IE=edge"
+              },
+              "Strict-Transport-Security": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "max-age=31536000; includeSubDomains; preload"
+              },
+              "X-Robots-Tag": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "none"
+              },
+              "Vary": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Accept-Encoding, Origin"
+              },
+              "Etag": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "W/\"9c35de2f4e0a8a6067d5506d3f586b80\""
+              },
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "max-age=0, private, must-revalidate"
+              },
+              "Content-Security-Policy": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "default-src 'self' https: blob:; connect-src 'self' ws: https: wss: file: https://edge.fullstory.com https://rs.fullstory.com https://sentry.io; img-src 'self' https: data: http: blob: https://www.googletagmanager.com https://rs.fullstory.com; object-src 'none'; script-src 'self' https: https://*.firebaseio.com https://www.googletagmanager.com https://edge.fullstory.com https://rs.fullstory.com https://js.hs-analytics.net https://www.google-analytics.com https://connect.facebook.net https://widget.intercom.io 'unsafe-inline' 'unsafe-eval'; worker-src 'self' https: blob:; style-src 'self' https: blob: 'unsafe-inline' 'unsafe-eval'; media-src 'self' https: data: blob:; font-src 'self' https: data: chrome-extension moz-extension https://fonts.gstatic.com http://themes.googleusercontent.com; report-uri /csp-report"
+              },
+              "X-Request-Id": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "fa89c053-4d89-4f7d-9fd3-66a7f13ffd59"
+              },
+              "X-Runtime": {
+                "schema": {
+                  "type": "number"
+                },
+                "example": "0.228651"
+              },
+              "Via": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "1.1 vegur"
+              },
+              "CF-Cache-Status": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "DYNAMIC"
+              },
+              "Report-To": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=pB%2BQrmZ6IH6AvSRgAbuq5gMeWPpDySlr09kdbvJ7r1iZ5rViwhzFfTP19qcX%2BuZ%2BiIYwMzYkPASeiuHSMusyEqmICJmMlsy2%2F7pEfucIwF%2FGTfAQwoQ03oqzLtKNHNoNAg%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              },
+              "NEL": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+              },
+              "Server": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "cloudflare"
+              },
+              "CF-RAY": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "7f0797673ee420cf-IAD"
+              },
+              "Content-Encoding": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "br"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "integer"
+                    },
+                    "pad_id": {
+                      "type": "integer"
+                    },
+                    "question_id": {
+                      "type": "null"
+                    },
+                    "example_question_id": {
+                      "type": "null"
+                    },
+                    "language": {
+                      "type": "string"
+                    },
+                    "file_contents": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "path": {
+                            "type": "string"
+                          },
+                          "contents": {
+                            "type": "string",
+                            "format": "style"
+                          },
+                          "history": {
+                            "type": "string",
+                            "format": "uri"
+                          }
+                        }
+                      }
+                    },
+                    "created_at": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "updated_at": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  }
+                },
+                "example": {
+                  "status": "OK",
+                  "id": 1234567,
+                  "pad_id": 88112233,
+                  "question_id": null,
+                  "example_question_id": null,
+                  "language": "java",
+                  "file_contents": [
+                    {
+                      "path": "coderpad/Solution.java",
+                      "contents": "/*\n * Click `Run` to execute the snippet below!\n */\n\nimport java.io.*;\nimport java.util.*;\n\n/*\n * To execute Java, please define \"static void main\" on a class\n * named Solution.\n *\n * If you need more classes, simply define them inline.\n */\n\nclass Solution {\n  public static void main(String[] args) {\n    ArrayList<String> strings = new ArrayList<String>();\n    strings.add(\"Hello, World!\");\n    strings.add(\"Welcome to CoderPad.\");\n    strings.add(\"This pad is running Java \" + Runtime.version().feature());\n\n    for (String string : strings) {\n      System.out.println(string);\n    }\n  }\n}\n",
+                      "history": "https://coderpad-7.firebaseio.com/4MT73N3J/environmentFiles/java/Y29kZXJwYWQvU29sdXRpb24uamF2YQ==/history.json"
+                    }
+                  ],
+                  "created_at": "2023-08-02T09:02:13.159-07:00",
+                  "updated_at": "2023-08-02T09:02:18.142-07:00"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["v1.0", "Pad Environments"],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "description": "Returns detail about a particular pad environment. Doing a straightforward curl like so:\n\n```\ncurl \\\n  -H 'Authorization: Token token=\"8af9a3412559d803707937250dc1569d\"' \\\n  https://app.coderpad.io/api/pad_environments/42\n\n ```\n\nyields:\n\n``` json\n{\n  \"status\": \"OK\",\n  \"id\": 1,\n  \"pad_id\": 3,\n  \"question_id\": null,\n  \"example_question_id\": null,\n  \"language\": \"ruby\",\n  \"file_contents\": [\n    {\n      \"path\": \"coderpad/main.rb\",\n      \"contents\": \"5.times do\\n  puts 'Hello, World!'\\nend\\n\"\n    }\n  ],\n  \"created_at\": \"2022-09-12T13:49:45.390-07:00\",\n  \"updated_at\": \"2022-09-12T13:50:42.058-07:00\"\n}\n\n ```\n\nFields returned:\n\n| Field | Description |\n| --- | --- |\n| id | `string` Primary key for the object. Use this to query or modify this resource later. |\n| pad_id | `string` The pad this environment belongs to. |\n| question_id | `string` If this is a question environment, this is the identifier for the question, otherwise null. |\n| example_question_id | `string` If you used one of CoderPad's example questions in the pad environment, the ID will be listed in this field. Example: `examples/035-django-shopping-list`. |\n| language | `string` Chosen language for the pad environment. One of a [set list](#Languages). |\n| file_contents | `object` Returns latest contents of pad environment. Note: If the environment language is a multi-file framework or project, for each file in the project a separate object with “path\", ”contents”, and “history” will be returned. See the `file_contents` object table below for more info. |\n| created_at | `datetime` When the environment was created, in UTC ISO 8601, like `2015-01-30T00:22:55.520Z`. |\n| updated_at | `datetime` Similarly, when the environment was last updated. |\n\nThe **file_contents** field contains information about the files associated with the environment. It is represented as an array of objects with the following fields:\n\n| Field | Description |\n| --- | --- |\n| path | `string` The path to the file. |\n| contents | `string` Initial contents of the file. Defaults to the example code for the language/file combination. |\n| history (optional) | `string` A URL that displays a JSON file that contains pad history information. This field will only be available once edits have been made to the pad. |\n\nAll values returned by this endpoint are real-time as of the moment you request them."
+      },
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "/api/questions/{id}": {
+      "get": {
+        "summary": "Retrieve a question by id",
+        "responses": {
+          "200": {
+            "description": "Successful request",
+            "headers": {
+              "Date": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Wed, 02 Aug 2023 17:59:02 GMT"
+              },
+              "Transfer-Encoding": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "chunked"
+              },
+              "Connection": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "keep-alive"
+              },
+              "X-Frame-Options": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "SAMEORIGIN"
+              },
+              "X-Xss-Protection": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "1; mode=block"
+              },
+              "X-Content-Type-Options": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "nosniff"
+              },
+              "X-Download-Options": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "noopen"
+              },
+              "X-Permitted-Cross-Domain-Policies": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "none"
+              },
+              "Referrer-Policy": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "strict-origin-when-cross-origin"
+              },
+              "X-Ua-Compatible": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "IE=edge"
+              },
+              "Strict-Transport-Security": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "max-age=31536000; includeSubDomains; preload"
+              },
+              "X-Robots-Tag": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "none"
+              },
+              "Vary": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Accept-Encoding, Origin"
+              },
+              "Etag": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "W/\"1642e67b00e362d11a88edbe1b4f3d76\""
+              },
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "max-age=0, private, must-revalidate"
+              },
+              "Content-Security-Policy": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "default-src 'self' https: blob:; connect-src 'self' ws: https: wss: file: https://edge.fullstory.com https://rs.fullstory.com https://sentry.io; img-src 'self' https: data: http: blob: https://www.googletagmanager.com https://rs.fullstory.com; object-src 'none'; script-src 'self' https: https://*.firebaseio.com https://www.googletagmanager.com https://edge.fullstory.com https://rs.fullstory.com https://js.hs-analytics.net https://www.google-analytics.com https://connect.facebook.net https://widget.intercom.io 'unsafe-inline' 'unsafe-eval'; worker-src 'self' https: blob:; style-src 'self' https: blob: 'unsafe-inline' 'unsafe-eval'; media-src 'self' https: data: blob:; font-src 'self' https: data: chrome-extension moz-extension https://fonts.gstatic.com http://themes.googleusercontent.com; report-uri /csp-report"
+              },
+              "X-Request-Id": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "d229f1dd-6ece-4034-a0ab-728a3b127169"
+              },
+              "X-Runtime": {
+                "schema": {
+                  "type": "number"
+                },
+                "example": "0.392650"
+              },
+              "Via": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "1.1 vegur"
+              },
+              "CF-Cache-Status": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "DYNAMIC"
+              },
+              "Report-To": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=APjnoi3XJJ%2FVA5OgGJcmboQpCh1i4HWFpmasq1hSv30DRAZSI8SAOycKZ4iOSGJREmuRRlbWOiK%2BjccE%2Bb%2FToFwWZjlGEv5mv7t6mHbV2ugY8QBtrVeZEgg9aubyixF4iw%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              },
+              "NEL": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+              },
+              "Server": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "cloudflare"
+              },
+              "CF-RAY": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "7f08365aef353ae4-IAD"
+              },
+              "Content-Encoding": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "br"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "integer"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "owner_email": {
+                      "type": "string",
+                      "format": "email"
+                    },
+                    "language": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "candidate_instructions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "instructions": {
+                            "type": "string",
+                            "format": "style"
+                          },
+                          "default_visible": {
+                            "type": "boolean"
+                          }
+                        }
+                      }
+                    },
+                    "contents": {
+                      "type": "string"
+                    },
+                    "shared": {
+                      "type": "boolean"
+                    },
+                    "used": {
+                      "type": "integer"
+                    },
+                    "take_home": {
+                      "type": "boolean"
+                    },
+                    "test_cases_enabled": {
+                      "type": "boolean"
+                    },
+                    "solution": {
+                      "type": "null"
+                    },
+                    "pad_type": {
+                      "type": "string"
+                    },
+                    "is_draft": {
+                      "type": "boolean"
+                    },
+                    "author_name": {
+                      "type": "string"
+                    },
+                    "organization_name": {
+                      "type": "string"
+                    },
+                    "custom_files": {
+                      "type": "array"
+                    },
+                    "created_at": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "updated_at": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  }
+                },
+                "example": {
+                  "status": "OK",
+                  "id": 123456,
+                  "title": "Parking Lot OO",
+                  "owner_email": "ken@coderpad.io",
+                  "language": "csharp",
+                  "description": "Example coding question testing knowledge of object-oriented principles for use during candidate interviews.",
+                  "candidate_instructions": [
+                    {
+                      "instructions": "Hey candidate! Welcome to your interview. Boilerplate is provided. Feel free to change the code as you see fit. To run the code at any time, please hit the run button located in the top left corner.\n\nGoals:\n  Design a parking lot using object-oriented principles\n\n  Here are a few methods that you should be able to run:\n- Tell us how many spots are remaining\n- Tell us how many total spots are in the parking lot\n- Tell us when the parking lot is full\n- Tell us when the parking lot is empty\n- Tell us when certain spots are full e.g. when all motorcycle spots are taken\n- Tell us how many spots vans are taking up\n\nAssumptions:\n- The parking lot can hold motorcycles, cars and vans\n- The parking lot has motorcycle spots, car spots and large spots\n- A motorcycle can park in any spot\n- A car can park in a single compact spot, or a regular spot\n- A van can park, but it will take up 3 regular spots\n- These are just a few assumptions. Feel free to ask your interviewer about more assumptions as needed \n",
+                      "default_visible": true
+                    }
+                  ],
+                  "contents": "using System;\n\n// To execute C#, please define \"static void Main\" on a class\n// named Solution.\n\nclass Solution\n{\n    static void Main(string[] args)\n    {\n        for (var i = 0; i < 5; i++)\n        {\n            Console.WriteLine(\"Hello, World\");\n        }\n    }\n}\n",
+                  "shared": true,
+                  "used": 1,
+                  "take_home": false,
+                  "test_cases_enabled": false,
+                  "solution": null,
+                  "pad_type": "any",
+                  "is_draft": false,
+                  "author_name": "ken",
+                  "organization_name": "CoderPad",
+                  "custom_files": [],
+                  "created_at": "2023-03-13T13:30:18Z",
+                  "updated_at": "2023-03-13T13:32:06Z"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["v1.0", "Questions"],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "description": "Returns details about a particular question. You can view questions visible to you, which includes your own questions as well as colleagues’ questions where `shared` is set to `true`. If you’re an organization owner, you can view all questions in the organization.\n\n```\ncurl \\\n  -H 'Authorization: Token token=\"8af9a3412559d803707937250dc1569d\"' \\\n  https://app.coderpad.io/api/questions/42\n\n ```\n\nyields:\n\n``` json\n{\n  \"status\": \"OK\",\n  \"id\": 42,\n  \"title\": \"Are fruits tomatoes?\",\n  \"author_name\": \"Molly Macadamia\",\n  \"owner_email\": \"molly@macadamia.net\",\n  \"language\": \"postgresql\",\n  \"description\": \"Use SQL magic to discover the answer.\",\n  \"contents\": \"SELECT * FROM fruits;\\n\",\n  \"shared\": true,\n  \"used\": 0,\n  \"created_at\": \"2019-01-25T02:07:12Z\",\n  \"updated_at\": \"2019-01-25T02:07:12Z\"\n}\n\n ```\n\nFields returned:\n\n| Field | Description |\n| --- | --- |\n| id | `string` Primary key for the object. Use this to query or modify this resource later. |\n| title | `string` User-assigned title of the question. |\n| author_name | `string` Name of the person who authored this question. This is the same person as the owner referenced by owner_email. |\n| owner_email | `string` Email address of the person who owns the question. |\n| language | `string` Chosen language for the question. One of a [set list](#Languages). |\n| description | `string` Notes for yourself (or colleagues) on what this question is about, and what good and bad answers might look like. |\n| contents | `string`User-assigned question contents. This text is inserted into your interview session if you choose to use this question. |\n| shared | `boolean` Specifies whether this question is shared with the user’s organization. Defaults to `true`. |\n| used | `int` A counter counting the number of times this question was used to create pads. |\n| created_at | `datetime` The time when the question was created, in UTC ISO 8601, like `2019-01-30T00:22:55.520Z`. |\n| updated_at | `datetime` Similarly, the time when the question was last updated. |"
+      },
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "put": {
+        "summary": "Modify a question",
+        "responses": {
+          "200": {
+            "description": "Successful request",
+            "headers": {
+              "Date": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Thu, 03 Aug 2023 11:31:13 GMT"
+              },
+              "Transfer-Encoding": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "chunked"
+              },
+              "Connection": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "keep-alive"
+              },
+              "X-Frame-Options": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "SAMEORIGIN"
+              },
+              "X-Xss-Protection": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "1; mode=block"
+              },
+              "X-Content-Type-Options": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "nosniff"
+              },
+              "X-Download-Options": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "noopen"
+              },
+              "X-Permitted-Cross-Domain-Policies": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "none"
+              },
+              "Referrer-Policy": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "strict-origin-when-cross-origin"
+              },
+              "X-Ua-Compatible": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "IE=edge"
+              },
+              "Strict-Transport-Security": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "max-age=31536000; includeSubDomains; preload"
+              },
+              "X-Robots-Tag": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "none"
+              },
+              "Vary": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Accept-Encoding, Origin"
+              },
+              "Etag": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "W/\"72584dcd6c422f0b08bebffd94121c8e\""
+              },
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "max-age=0, private, must-revalidate"
+              },
+              "Content-Security-Policy": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "default-src 'self' https: blob:; connect-src 'self' ws: https: wss: file: https://edge.fullstory.com https://rs.fullstory.com https://sentry.io; img-src 'self' https: data: http: blob: https://www.googletagmanager.com https://rs.fullstory.com; object-src 'none'; script-src 'self' https: https://*.firebaseio.com https://www.googletagmanager.com https://edge.fullstory.com https://rs.fullstory.com https://js.hs-analytics.net https://www.google-analytics.com https://connect.facebook.net https://widget.intercom.io 'unsafe-inline' 'unsafe-eval'; worker-src 'self' https: blob:; style-src 'self' https: blob: 'unsafe-inline' 'unsafe-eval'; media-src 'self' https: data: blob:; font-src 'self' https: data: chrome-extension moz-extension https://fonts.gstatic.com http://themes.googleusercontent.com; report-uri /csp-report"
+              },
+              "X-Request-Id": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "691e6841-7f44-42df-9cb3-2a1d7bcc05ba"
+              },
+              "X-Runtime": {
+                "schema": {
+                  "type": "number"
+                },
+                "example": "0.084143"
+              },
+              "Via": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "1.1 vegur"
+              },
+              "CF-Cache-Status": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "DYNAMIC"
+              },
+              "Report-To": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=TJaTDQk48jkAj1vN3uznnEYVuoga129EwC%2B1RwKBotXgIm54nIXymnEPsczUik6NWFIvYU%2Bnu92DejvS%2FYolrkDHjO4CgYM89rprksopHdsSTVBIwm%2FS5mdWEG3iBn5Qrw%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              },
+              "NEL": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+              },
+              "Server": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "cloudflare"
+              },
+              "CF-RAY": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "7f0e3ba848997f72-IAD"
+              },
+              "Content-Encoding": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "br"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "example": {
+                  "status": "OK"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["v1.0", "Questions"],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "description": "Modifies an existing question. You can specify any of the valid parameters to `create`.\n\n```\ncurl \\\n  -X PUT --data description=\"We've noticed candidates from the West coast have substantial experience with avocados, so this question is worth less points now.\" \\\n  -H 'Authorization: Token token=\"8af9a3412559d803707937250dc1569d\"' \\\n  https://app.coderpad.io/api/questions/42\n\n ```"
+      },
+      "delete": {
+        "summary": "Delete a question",
+        "responses": {
+          "200": {
+            "description": "Successful request",
+            "headers": {
+              "Date": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Thu, 03 Aug 2023 11:40:32 GMT"
+              },
+              "Transfer-Encoding": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "chunked"
+              },
+              "Connection": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "keep-alive"
+              },
+              "X-Frame-Options": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "SAMEORIGIN"
+              },
+              "X-Xss-Protection": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "1; mode=block"
+              },
+              "X-Content-Type-Options": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "nosniff"
+              },
+              "X-Download-Options": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "noopen"
+              },
+              "X-Permitted-Cross-Domain-Policies": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "none"
+              },
+              "Referrer-Policy": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "strict-origin-when-cross-origin"
+              },
+              "X-Ua-Compatible": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "IE=edge"
+              },
+              "Strict-Transport-Security": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "max-age=31536000; includeSubDomains; preload"
+              },
+              "X-Robots-Tag": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "none"
+              },
+              "Vary": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Accept-Encoding, Origin"
+              },
+              "Etag": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "W/\"131d1467f1f0479ef1a1f1715dd8e37a\""
+              },
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "max-age=0, private, must-revalidate"
+              },
+              "Content-Security-Policy": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "default-src 'self' https: blob:; connect-src 'self' ws: https: wss: file: https://edge.fullstory.com https://rs.fullstory.com https://sentry.io; img-src 'self' https: data: http: blob: https://www.googletagmanager.com https://rs.fullstory.com; object-src 'none'; script-src 'self' https: https://*.firebaseio.com https://www.googletagmanager.com https://edge.fullstory.com https://rs.fullstory.com https://js.hs-analytics.net https://www.google-analytics.com https://connect.facebook.net https://widget.intercom.io 'unsafe-inline' 'unsafe-eval'; worker-src 'self' https: blob:; style-src 'self' https: blob: 'unsafe-inline' 'unsafe-eval'; media-src 'self' https: data: blob:; font-src 'self' https: data: chrome-extension moz-extension https://fonts.gstatic.com http://themes.googleusercontent.com; report-uri /csp-report"
+              },
+              "X-Request-Id": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "71b0cd2e-d38b-4e51-921d-ad77d1ca78f7"
+              },
+              "X-Runtime": {
+                "schema": {
+                  "type": "number"
+                },
+                "example": "0.055374"
+              },
+              "Via": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "1.1 vegur"
+              },
+              "CF-Cache-Status": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "DYNAMIC"
+              },
+              "Report-To": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=8Cv9hJA8nRvC%2Fmf7wMHyoYJ%2Fq0O%2FHEKLB%2B26vrFqBvvwiDMQo7qOPRoav2ji7HaujL0LASLetgD80RjDFv57Hu%2B86GYpZgKAmBKTMdJO1kvSpYoASijO1ylpp%2BYvd5pn%2FQ%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              },
+              "NEL": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+              },
+              "Server": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "cloudflare"
+              },
+              "CF-RAY": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "7f0e494ebf8e062b-IAD"
+              },
+              "Content-Encoding": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "br"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "example": {
+                  "status": "OK"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["v1.0", "Questions"],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "description": "Deletes an existing question. There is no undo!\n\n```\ncurl \\\n  -X DELETE \\\n  -H 'Authorization: Token token=\"8af9a3412559d803707937250dc1569d\"' \\\n  https://app.coderpad.io/api/questions/42\n\n ```"
+      }
+    },
+    "/api/questions/": {
+      "get": {
+        "summary": "Retrieve a list of questions",
+        "responses": {
+          "200": {
+            "description": "Successful request",
+            "headers": {
+              "Date": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Wed, 02 Aug 2023 18:04:34 GMT"
+              },
+              "Transfer-Encoding": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "chunked"
+              },
+              "Connection": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "keep-alive"
+              },
+              "X-Frame-Options": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "SAMEORIGIN"
+              },
+              "X-Xss-Protection": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "1; mode=block"
+              },
+              "X-Content-Type-Options": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "nosniff"
+              },
+              "X-Download-Options": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "noopen"
+              },
+              "X-Permitted-Cross-Domain-Policies": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "none"
+              },
+              "Referrer-Policy": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "strict-origin-when-cross-origin"
+              },
+              "X-Ua-Compatible": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "IE=edge"
+              },
+              "Strict-Transport-Security": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "max-age=31536000; includeSubDomains; preload"
+              },
+              "X-Robots-Tag": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "none"
+              },
+              "Vary": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Accept-Encoding, Origin"
+              },
+              "Etag": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "W/\"a3dc0332b50336fbd15d720cdeff6851\""
+              },
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "max-age=0, private, must-revalidate"
+              },
+              "Content-Security-Policy": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "default-src 'self' https: blob:; connect-src 'self' ws: https: wss: file: https://edge.fullstory.com https://rs.fullstory.com https://sentry.io; img-src 'self' https: data: http: blob: https://www.googletagmanager.com https://rs.fullstory.com; object-src 'none'; script-src 'self' https: https://*.firebaseio.com https://www.googletagmanager.com https://edge.fullstory.com https://rs.fullstory.com https://js.hs-analytics.net https://www.google-analytics.com https://connect.facebook.net https://widget.intercom.io 'unsafe-inline' 'unsafe-eval'; worker-src 'self' https: blob:; style-src 'self' https: blob: 'unsafe-inline' 'unsafe-eval'; media-src 'self' https: data: blob:; font-src 'self' https: data: chrome-extension moz-extension https://fonts.gstatic.com http://themes.googleusercontent.com; report-uri /csp-report"
+              },
+              "X-Request-Id": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "c196484b-8e45-44c4-a107-dd4332c9c800"
+              },
+              "X-Runtime": {
+                "schema": {
+                  "type": "number"
+                },
+                "example": "0.706690"
+              },
+              "Via": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "1.1 vegur"
+              },
+              "CF-Cache-Status": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "DYNAMIC"
+              },
+              "Report-To": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=iq4I7qOwyWEraqDqhHgDCYszF1DC28p9P%2Bu%2BeCW%2FNW5U5lBB%2FdwV3QTQ%2FZBQCgbv4Hw0LFpMq%2Bwr%2BFpz3oMrVkioBsFIuvitXfOFb8cC7myOt9ZnOIKzxMHsp2MTb5WgJA%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              },
+              "NEL": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+              },
+              "Server": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "cloudflare"
+              },
+              "CF-RAY": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "7f083e787b236faa-IAD"
+              },
+              "Content-Encoding": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "br"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string"
+                    },
+                    "questions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "owner_email": {
+                            "type": "string",
+                            "format": "email"
+                          },
+                          "language": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "candidate_instructions": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "instructions": {
+                                  "type": "string"
+                                },
+                                "default_visible": {
+                                  "type": "boolean"
+                                }
+                              }
+                            }
+                          },
+                          "contents": {
+                            "type": "null"
+                          },
+                          "shared": {
+                            "type": "boolean"
+                          },
+                          "used": {
+                            "type": "integer"
+                          },
+                          "take_home": {
+                            "type": "boolean"
+                          },
+                          "test_cases_enabled": {
+                            "type": "boolean"
+                          },
+                          "solution": {
+                            "type": "string"
+                          },
+                          "pad_type": {
+                            "type": "string"
+                          },
+                          "is_draft": {
+                            "type": "boolean"
+                          },
+                          "author_name": {
+                            "type": "string"
+                          },
+                          "organization_name": {
+                            "type": "string"
+                          },
+                          "custom_files": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string"
+                                },
+                                "title": {
+                                  "type": "string"
+                                },
+                                "description": {
+                                  "type": "string"
+                                },
+                                "filename": {
+                                  "type": "string"
+                                },
+                                "filesize": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "public_take_home_setting_id": {
+                            "type": "integer"
+                          },
+                          "contents_for_test_cases": {
+                            "type": "string"
+                          },
+                          "test_cases": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "integer"
+                                },
+                                "return_value": {
+                                  "type": "string"
+                                },
+                                "visible": {
+                                  "type": "boolean"
+                                },
+                                "arguments": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string",
+                                    "format": "utc-millisec"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "created_at": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "updated_at": {
+                            "type": "string",
+                            "format": "date-time"
+                          }
+                        }
+                      }
+                    },
+                    "next_page": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "total": {
+                      "type": "integer"
+                    }
+                  }
+                },
+                "example": {
+                  "status": "OK",
+                  "questions": [
+                    {
+                      "id": 12345,
+                      "title": "Request Construction",
+                      "owner_email": "ken@coderpad.io",
+                      "language": "ruby",
+                      "description": "In this Challenge, we ask candidates to take an array of objects to do stuff. Their\n- should be well-organized and well-commented",
+                      "candidate_instructions": [
+                        {
+                          "instructions": "# Welcome to the CoderPad Playback Challenge!\r\n\r\nAs one of the first steps in the interview process, you'll be completeing this puzzle.",
+                          "default_visible": true
+                        }
+                      ],
+                      "contents": null,
+                      "shared": true,
+                      "used": 795,
+                      "take_home": true,
+                      "test_cases_enabled": true,
+                      "solution": "",
+                      "pad_type": "take_home",
+                      "is_draft": false,
+                      "author_name": "Ray Sunshine",
+                      "organization_name": "CoderPad",
+                      "custom_files": [
+                        {
+                          "id": "12345-dfsdfs-32342-dfsdfsd",
+                          "title": "CSV file",
+                          "description": "A CSV of bank accounts",
+                          "filename": "accounts.csv",
+                          "filesize": "6.11 KB"
+                        }
+                      ],
+                      "public_take_home_setting_id": 36,
+                      "contents_for_test_cases": "def solution(target_timestamp)\n  # Please write your code here.\n  \"example\"\nend\n",
+                      "test_cases": [
+                        {
+                          "id": 756,
+                          "return_value": "\"const _ = require('lodash');\\n\\nfunction sayWhat(what) {\\n  console.log('Hello, World');\\n  console.log(`\\n}\\n\\n_.times(5, sayHello);\\n\"",
+                          "visible": false,
+                          "arguments": ["1583819946183"]
+                        },
+                        {
+                          "id": 757,
+                          "return_value": "\"\"",
+                          "visible": false,
+                          "arguments": ["-232"]
+                        },
+                        {
+                          "id": 758,
+                          "return_value": "\"\"",
+                          "visible": false,
+                          "arguments": ["0"]
+                        }
+                      ],
+                      "created_at": "2020-08-17T07:27:53Z",
+                      "updated_at": "2023-03-09T17:42:58Z"
+                    },
+                    {
+                      "id": 45678,
+                      "title": "Fix this fizzbuzz",
+                      "owner_email": "ken@coderpad.io",
+                      "language": "ruby",
+                      "description": "debug challenge",
+                      "candidate_instructions": [
+                        {
+                          "instructions": ""
+                        }
+                      ],
+                      "contents": "# What's wrong with this FizzBuzz implementation? ",
+                      "shared": true,
+                      "used": 555,
+                      "take_home": false,
+                      "test_cases_enabled": false,
+                      "solution": "The buzz is fizzed by 5",
+                      "pad_type": "live",
+                      "is_draft": false,
+                      "author_name": "Ken (CoderPad)",
+                      "organization_name": "CoderPad",
+                      "custom_files": [],
+                      "created_at": "2017-09-12T18:30:54Z",
+                      "updated_at": "2023-01-27T19:47:07Z"
+                    }
+                  ],
+                  "next_page": "https://app.coderpad.io/api/questions?page=2",
+                  "total": 816
+                }
+              }
+            }
+          }
+        },
+        "tags": ["v1.0", "Questions"],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "description": "Fetch a list of all of your questions. Returns all fields that an individual _Get question by id_ request does.\n\n```\ncurl \\\n  -H 'Authorization: Token token=\"8af9a3412559d803707937250dc1569d\"' \\\n  https://app.coderpad.io/api/questions?sort=updated_at,desc\n\n ```\n\n`index` takes an optional `sort` parameter, which allows you to sort by either the `created_at` or `updated_at` fields on the questions. Adding a comma will allow you to change the sort direction, which is `desc` by default. For example, to sort your questions by `updated_at` from oldest to newest, specify `updated_at,asc`.\n\nIf no `sort` parameter is provided, `created_at,desc` is assumed.\n\nThe method also returns paginated results - no more than 50 per request. If you want more, follow the `next_page` or `prev_page` urls if present. The API also returns a `total` count to give you a sense of how many questions exist.\n\n``` json\n{\n  \"status\": \"OK\",\n  \"questions\": [\n    // ... your questions, with the same data format as in `show`\n  ],\n  \"next_page\": \"https://app.coderpad.io/api/question?sort=updated_at,desc&page=2\",\n  \"total\": 420\n}\n\n ```"
+      },
+      "post": {
+        "summary": "Create a question",
+        "responses": {
+          "200": {
+            "description": "Successful request",
+            "headers": {
+              "Date": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Thu, 03 Aug 2023 11:32:56 GMT"
+              },
+              "Transfer-Encoding": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "chunked"
+              },
+              "Connection": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "keep-alive"
+              },
+              "X-Frame-Options": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "SAMEORIGIN"
+              },
+              "X-Xss-Protection": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "1; mode=block"
+              },
+              "X-Content-Type-Options": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "nosniff"
+              },
+              "X-Download-Options": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "noopen"
+              },
+              "X-Permitted-Cross-Domain-Policies": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "none"
+              },
+              "Referrer-Policy": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "strict-origin-when-cross-origin"
+              },
+              "X-Ua-Compatible": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "IE=edge"
+              },
+              "Strict-Transport-Security": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "max-age=31536000; includeSubDomains; preload"
+              },
+              "X-Robots-Tag": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "none"
+              },
+              "Vary": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Accept-Encoding, Origin"
+              },
+              "Etag": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "W/\"12bcb32dc651c297dacc827e20d5d924\""
+              },
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "max-age=0, private, must-revalidate"
+              },
+              "Content-Security-Policy": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "default-src 'self' https: blob:; connect-src 'self' ws: https: wss: file: https://edge.fullstory.com https://rs.fullstory.com https://sentry.io; img-src 'self' https: data: http: blob: https://www.googletagmanager.com https://rs.fullstory.com; object-src 'none'; script-src 'self' https: https://*.firebaseio.com https://www.googletagmanager.com https://edge.fullstory.com https://rs.fullstory.com https://js.hs-analytics.net https://www.google-analytics.com https://connect.facebook.net https://widget.intercom.io 'unsafe-inline' 'unsafe-eval'; worker-src 'self' https: blob:; style-src 'self' https: blob: 'unsafe-inline' 'unsafe-eval'; media-src 'self' https: data: blob:; font-src 'self' https: data: chrome-extension moz-extension https://fonts.gstatic.com http://themes.googleusercontent.com; report-uri /csp-report"
+              },
+              "X-Request-Id": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "8e770d56-c86d-4d41-b867-7dc1e1d7fc77"
+              },
+              "X-Runtime": {
+                "schema": {
+                  "type": "number"
+                },
+                "example": "0.056612"
+              },
+              "Via": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "1.1 vegur"
+              },
+              "CF-Cache-Status": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "DYNAMIC"
+              },
+              "Report-To": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=kTE4f3HJ%2FntQ8lC9WGiDgSkURK6OdkFvyVkSAhZcZwHagzMOKBeZwX4uwRvN%2BllvlwVlZUp1BwfGCtZAaQumHRVmsMudAcABDTvCAZtz6zSuYGOj92ymZ%2FVQ3isu%2BM4keA%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              },
+              "NEL": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+              },
+              "Server": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "cloudflare"
+              },
+              "CF-RAY": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "7f0e3e2e9a91826f-IAD"
+              },
+              "Content-Encoding": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "br"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "integer"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "owner_email": {
+                      "type": "string",
+                      "format": "email"
+                    },
+                    "language": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "null"
+                    },
+                    "candidate_instructions": {
+                      "type": "array"
+                    },
+                    "contents": {
+                      "type": "null"
+                    },
+                    "shared": {
+                      "type": "boolean"
+                    },
+                    "used": {
+                      "type": "integer"
+                    },
+                    "take_home": {
+                      "type": "boolean"
+                    },
+                    "test_cases_enabled": {
+                      "type": "boolean"
+                    },
+                    "solution": {
+                      "type": "null"
+                    },
+                    "pad_type": {
+                      "type": "string"
+                    },
+                    "is_draft": {
+                      "type": "boolean"
+                    },
+                    "author_name": {
+                      "type": "string"
+                    },
+                    "organization_name": {
+                      "type": "string"
+                    },
+                    "custom_files": {
+                      "type": "array"
+                    },
+                    "created_at": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "updated_at": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  }
+                },
+                "example": {
+                  "status": "OK",
+                  "id": 255896,
+                  "title": "Are avocados fruity?",
+                  "owner_email": "ken@coderpad.io",
+                  "language": "ruby",
+                  "description": null,
+                  "candidate_instructions": [],
+                  "contents": null,
+                  "shared": true,
+                  "used": 0,
+                  "take_home": false,
+                  "test_cases_enabled": false,
+                  "solution": null,
+                  "pad_type": "live",
+                  "is_draft": false,
+                  "author_name": "ken",
+                  "organization_name": "CoderPad",
+                  "custom_files": [],
+                  "created_at": "2023-08-03T11:32:56Z",
+                  "updated_at": "2023-08-03T11:32:56Z"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["v1.0", "Questions"],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "description": "Create a new question.\n\n```\ncurl \\\n  --data title=\"Are avocados fruity?\" \\\n  --data description=\"Fruit puzzler round 2\" \\\n  --data language=\"ruby\" \\\n  --data contents=\"def is_fruity?(thing);\\n  end\\n\" \\\n  --data solution=\"This is the solution\" \\\n  --data candidate_instructions=\"[{'instructions': 'Implement the is_fruity method'}]\" \\\n  -H 'Authorization: Token token=\"8af9a3412559d803707937250dc1569d\"' \\\n  https://app.coderpad.io/api/questions\n\n ```\n\nreturns the question just created:\n\n``` json\n{\n  \"status\": \"OK\",\n  \"id\": 7,\n  \"title\": \"Are avocados fruity?\",\n  \"owner_email\": \"alice@fruits-party.io\",\n  \"language\": \"ruby\",\n  \"description\": \"Fruit puzzler round 2\",\n  \"contents\": \"def is_fruity?(thing);\\n  end\\n\",\n  \"shared\": true,\n  \"used\": 0,\n  \"created_at\": \"2019-01-28T21:21:16Z\",\n  \"updated_at\": \"2019-01-28T21:21:16Z\"\n}\n\n ```\n\nThe available paramters you have to configure are detailed below:\n\n| Field | Description |\n| --- | --- |\n| id | `string` Primary key for the object. Use this to query or modify this resource later. |\n| title | `string` Title for this question. |\n| language | `string` One of a [set list](#Languages). |\n| description | `string` Notes for yourself (or colleagues) on what this question is about, and what good and bad answers might look like. |\n| contents | `string` This text is inserted into your interview session if you choose to use this question. |"
+      }
+    },
+    "/api/quota": {
+      "get": {
+        "summary": "Retrieve quota information",
+        "responses": {
+          "200": {
+            "description": "Successful request",
+            "headers": {
+              "Date": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Thu, 03 Aug 2023 12:13:30 GMT"
+              },
+              "Transfer-Encoding": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "chunked"
+              },
+              "Connection": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "keep-alive"
+              },
+              "X-Frame-Options": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "SAMEORIGIN"
+              },
+              "X-Xss-Protection": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "1; mode=block"
+              },
+              "X-Content-Type-Options": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "nosniff"
+              },
+              "X-Download-Options": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "noopen"
+              },
+              "X-Permitted-Cross-Domain-Policies": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "none"
+              },
+              "Referrer-Policy": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "strict-origin-when-cross-origin"
+              },
+              "X-Ua-Compatible": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "IE=edge"
+              },
+              "Strict-Transport-Security": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "max-age=31536000; includeSubDomains; preload"
+              },
+              "Vary": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Accept, Accept-Encoding, Origin"
+              },
+              "X-Robots-Tag": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "none"
+              },
+              "Etag": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "W/\"f784baab0651711d7b1c69f119ea36b6\""
+              },
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "max-age=0, private, must-revalidate"
+              },
+              "Content-Security-Policy": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "default-src 'self' https: blob:; connect-src 'self' ws: https: wss: file: https://edge.fullstory.com https://rs.fullstory.com https://sentry.io; img-src 'self' https: data: http: blob: https://www.googletagmanager.com https://rs.fullstory.com; object-src 'none'; script-src 'self' https: https://*.firebaseio.com https://www.googletagmanager.com https://edge.fullstory.com https://rs.fullstory.com https://js.hs-analytics.net https://www.google-analytics.com https://connect.facebook.net https://widget.intercom.io 'unsafe-inline' 'unsafe-eval'; worker-src 'self' https: blob:; style-src 'self' https: blob: 'unsafe-inline' 'unsafe-eval'; media-src 'self' https: data: blob:; font-src 'self' https: data: chrome-extension moz-extension https://fonts.gstatic.com http://themes.googleusercontent.com; report-uri /csp-report"
+              },
+              "X-Request-Id": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "0f592453-4e85-46a5-97c3-3ed9510b6520"
+              },
+              "X-Runtime": {
+                "schema": {
+                  "type": "number"
+                },
+                "example": "0.046574"
+              },
+              "Via": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "1.1 vegur"
+              },
+              "CF-Cache-Status": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "DYNAMIC"
+              },
+              "Report-To": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=8sRcUIrwzPWReKUdWTQpFhKjc44Mcz6ZlHksNJmZZTOAFS77mwqkRFxeb9SFibhJpdohN4Yo1NmTaxjE12QXsqEa%2BYGkmzLL2%2FwLMbZaV8a1%2BGUiHP0RdDih2XmB0uE82g%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              },
+              "NEL": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+              },
+              "Server": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "cloudflare"
+              },
+              "CF-RAY": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "7f0e7998997e8006-IAD"
+              },
+              "Content-Encoding": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "br"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string"
+                    },
+                    "trial_expires_at": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "pads_used": {
+                      "type": "integer"
+                    },
+                    "quota_reset_at": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "unlimited": {
+                      "type": "boolean"
+                    },
+                    "overages_enabled": {
+                      "type": "boolean"
+                    }
+                  }
+                },
+                "example": {
+                  "status": "OK",
+                  "trial_expires_at": "2023-06-07T05:30:11.437-07:00",
+                  "pads_used": 270,
+                  "quota_reset_at": "2023-07-16T20:11:59.208-07:00",
+                  "unlimited": true,
+                  "overages_enabled": false
+                }
+              }
+            }
+          }
+        },
+        "tags": ["v1.0", "Quota"],
+        "description": "This endpoint returns basic information about your organization’s monthly pad quota (or your quota, if you are not a part of an organization). For example, if you are a user in an organization with a monthly quota of 120 pads, the following:\n\n```\ncurl \\\n  -H 'Authorization: Token token=\"8af9a3412559d803707937250dc1569d\"' \\\n  https://app.coderpad.io/api/quota\n\n ```\n\nreturns:\n\n``` json\n{\n  \"status\": \"OK\",\n  \"trial_expires_at\": \"2018-01-30T16:16:00.000-08:00\",\n  \"pads_used\": 33,\n  \"quota_reset_at\": \"2018-01-25T14:51:37.084-08:00\",\n  \"unlimited\": false,\n  \"pads_remaining\": 87,\n  \"billing_cycle_pad_limit\": 120\n}\n\n ```\n\nFields returned:\n\n| Field | Description |\n| --- | --- |\n| trial_expires_at | `datetime` The date your trial will expire, or has expired, in UTC ISO 8601 format (e.g., `2018-01-25T14:51:37.084-08:00`). |\n| pads_used | `int` The number of pads used during the current billing cycle. |\n| quota_reset_at | `datetime` The date, in UTC ISO 8601, that your quota was last reset. Pad quotas are reset every billing cycle. |\n| unlimited | `boolean` Indicates whether your billing plan allows for unmetered usage. |\n| pads_remaining | `int` The number of pads remaining for the current billing cycle. Not returned if `unlimited` is true. |\n| billing_cycle_pad_limit | `int` The total number of pads allocated for the billing cycle. Not returned if `unlimited` is true. |"
+      }
+    },
+    "/api/organization": {
+      "get": {
+        "summary": "Retrieve account info",
+        "responses": {
+          "200": {
+            "description": "Successful request",
+            "headers": {
+              "Date": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Thu, 03 Aug 2023 13:17:40 GMT"
+              },
+              "Transfer-Encoding": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "chunked"
+              },
+              "Connection": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "keep-alive"
+              },
+              "X-Frame-Options": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "SAMEORIGIN"
+              },
+              "X-Xss-Protection": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "1; mode=block"
+              },
+              "X-Content-Type-Options": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "nosniff"
+              },
+              "X-Download-Options": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "noopen"
+              },
+              "X-Permitted-Cross-Domain-Policies": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "none"
+              },
+              "Referrer-Policy": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "strict-origin-when-cross-origin"
+              },
+              "X-Ua-Compatible": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "IE=edge"
+              },
+              "Strict-Transport-Security": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "max-age=31536000; includeSubDomains; preload"
+              },
+              "Vary": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Accept, Accept-Encoding, Origin"
+              },
+              "X-Robots-Tag": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "none"
+              },
+              "Etag": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "W/\"df82eac08b4aa36a42fb92c3e0161248\""
+              },
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "max-age=0, private, must-revalidate"
+              },
+              "Content-Security-Policy": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "default-src 'self' https: blob:; connect-src 'self' ws: https: wss: file: https://edge.fullstory.com https://rs.fullstory.com https://sentry.io; img-src 'self' https: data: http: blob: https://www.googletagmanager.com https://rs.fullstory.com; object-src 'none'; script-src 'self' https: https://*.firebaseio.com https://www.googletagmanager.com https://edge.fullstory.com https://rs.fullstory.com https://js.hs-analytics.net https://www.google-analytics.com https://connect.facebook.net https://widget.intercom.io 'unsafe-inline' 'unsafe-eval'; worker-src 'self' https: blob:; style-src 'self' https: blob: 'unsafe-inline' 'unsafe-eval'; media-src 'self' https: data: blob:; font-src 'self' https: data: chrome-extension moz-extension https://fonts.gstatic.com http://themes.googleusercontent.com; report-uri /csp-report"
+              },
+              "Set-Cookie": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "_coderpad_rails_session_3=53ca943824368879ad426e8502ebcd38; domain=.coderpad.io; path=/; secure; HttpOnly; SameSite=Lax"
+              },
+              "X-Request-Id": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "fbe8c92f-eee6-4817-b446-85afb226c263"
+              },
+              "X-Runtime": {
+                "schema": {
+                  "type": "number"
+                },
+                "example": "0.054772"
+              },
+              "Via": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "1.1 vegur"
+              },
+              "CF-Cache-Status": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "DYNAMIC"
+              },
+              "Report-To": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=673ET%2FvOZyzDdx9ES9G%2BBB84v9GLyGTJHrW1Wh9nrlP8tewuvecArtGEi7SFfUGi80JeuRZPtd8pKtmLV70IYaSvaYnBF%2FxI3YjlbpCSQ%2BsxFxf19inDB4JcnpHe8FR9Gg%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              },
+              "NEL": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+              },
+              "Server": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "cloudflare"
+              },
+              "CF-RAY": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "7f0ed7999cd759c1-IAD"
+              },
+              "Content-Encoding": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "br"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string"
+                    },
+                    "organization_name": {
+                      "type": "string"
+                    },
+                    "user_count": {
+                      "type": "integer"
+                    },
+                    "users": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "email": {
+                            "type": "string",
+                            "format": "email"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "teams": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "organization_default_language": {
+                      "type": "string"
+                    },
+                    "single_sign_on_supported": {
+                      "type": "boolean"
+                    },
+                    "single_sign_in_url": {
+                      "type": "string"
+                    },
+                    "teams": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "status": "OK",
+                  "organization_name": "Company",
+                  "user_count": 3,
+                  "users": [
+                    {
+                      "email": "user.one@company.io",
+                      "name": "user.one",
+                      "teams": [
+                        "68264172-5a54-4ac3-962b-cb8d1ad15d05",
+                        "4a0f61a3-3013-49f5-9eb7-9f83712a49bf",
+                        "ddc4ce0a-93ec-4bad-9a1a-3d2db96f6220"
+                      ]
+                    },
+                    {
+                      "email": "person.two@company.io",
+                      "name": "person.two",
+                      "teams": ["4a0f61a3-3013-49f5-9eb7-9f83712a49bf"]
+                    },
+                    {
+                      "email": "buddy@company.io",
+                      "name": "Buddy",
+                      "teams": [
+                        "68264172-5a54-4ac3-962b-cb8d1ad15d05",
+                        "ddc4ce0a-93ec-4bad-9a1a-3d2db96f6220"
+                      ]
+                    }
+                  ],
+                  "organization_default_language": "java",
+                  "single_sign_on_supported": true,
+                  "single_sign_in_url": "login.company.io",
+                  "teams": [
+                    {
+                      "id": "68264172-5a54-4ac3-962b-cb8d1ad15d05",
+                      "name": "Main Team"
+                    },
+                    {
+                      "id": "4a0f61a3-3013-49f5-9eb7-9f83712a49bf",
+                      "name": "Second Team"
+                    },
+                    {
+                      "id": "ddc4ce0a-93ec-4bad-9a1a-3d2db96f6220",
+                      "name": "Third Team"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "tags": ["v1.0", "Organization"],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "description": "This endpoint returns basic information about your organization, including whether or not your organization makes use of a single-sign-on service for authentication.\n\n```\ncurl \\\n  -H 'Authorization: Token token=\"8af9a3412559d803707937250dc1569d\"' \\\n  https://app.coderpad.io/api/organization\n\n ```\n\nreturns\n\n``` json\n{\n  \"status\": \"OK\",\n  \"organization_name\": \"ACME Computing\",\n  \"user_count\": 137,\n  \"users\": [\n    {\n      \"email\": \"wile@acme.com\",\n      \"name\": \"Wile Coyote\",\n      \"teams\": [\n        \"68264172-5a54-4ac3-962b-cb8d1ad15d05\",\n        \"4a0f61a3-3013-49f5-9eb7-9f83712a49bf\"\n      ]\n    }\n    // ... followed by the rest of the users in your org.\n  ],\n  \"default_language\": \"erlang\", // default language for new users in your organization\n  \"single_sign_on_supported\": true, // users will be directed to login via the single sign in portal\n  \"single_sign_in_url\": acme.coderpad.io, // the url for that portal.\n  \"teams\": [ // The teams names and ids\n    {\n      \"id\": \"68264172-5a54-4ac3-962b-cb8d1ad15d05\",\n      \"name\": \"Main Team\"\n    },\n    {\n      \"id\": \"4a0f61a3-3013-49f5-9eb7-9f83712a49bf\",\n      \"name\": \"Second Team\"\n    },\n    {\n      \"id\": \"ddc4ce0a-93ec-4bad-9a1a-3d2db96f6220\",\n      \"name\": \"Third Team\"\n    }\n  ]\n}\n\n ```"
+      }
+    },
+    "/api/organization/stats": {
+      "get": {
+        "summary": "Retrieve pad usage stats",
+        "responses": {
+          "200": {
+            "description": "Successful request",
+            "headers": {
+              "Date": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Thu, 03 Aug 2023 14:27:21 GMT"
+              },
+              "Transfer-Encoding": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "chunked"
+              },
+              "Connection": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "keep-alive"
+              },
+              "X-Frame-Options": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "SAMEORIGIN"
+              },
+              "X-Xss-Protection": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "1; mode=block"
+              },
+              "X-Content-Type-Options": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "nosniff"
+              },
+              "X-Download-Options": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "noopen"
+              },
+              "X-Permitted-Cross-Domain-Policies": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "none"
+              },
+              "Referrer-Policy": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "strict-origin-when-cross-origin"
+              },
+              "X-Ua-Compatible": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "IE=edge"
+              },
+              "Strict-Transport-Security": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "max-age=31536000; includeSubDomains; preload"
+              },
+              "Vary": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Accept, Accept-Encoding, Origin"
+              },
+              "X-Robots-Tag": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "none"
+              },
+              "Etag": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "W/\"1371564988e510d5f1c872e9d9c8464e\""
+              },
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "max-age=0, private, must-revalidate"
+              },
+              "Content-Security-Policy": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "default-src 'self' https: blob:; connect-src 'self' ws: https: wss: file: https://edge.fullstory.com https://rs.fullstory.com https://sentry.io; img-src 'self' https: data: http: blob: https://www.googletagmanager.com https://rs.fullstory.com; object-src 'none'; script-src 'self' https: https://*.firebaseio.com https://www.googletagmanager.com https://edge.fullstory.com https://rs.fullstory.com https://js.hs-analytics.net https://www.google-analytics.com https://connect.facebook.net https://widget.intercom.io 'unsafe-inline' 'unsafe-eval'; worker-src 'self' https: blob:; style-src 'self' https: blob: 'unsafe-inline' 'unsafe-eval'; media-src 'self' https: data: blob:; font-src 'self' https: data: chrome-extension moz-extension https://fonts.gstatic.com http://themes.googleusercontent.com; report-uri /csp-report"
+              },
+              "X-Request-Id": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "9f8c5e83-3cd5-480d-ac25-036f3734863f"
+              },
+              "X-Runtime": {
+                "schema": {
+                  "type": "number"
+                },
+                "example": "0.081133"
+              },
+              "Via": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "1.1 vegur"
+              },
+              "CF-Cache-Status": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "DYNAMIC"
+              },
+              "Report-To": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=DAeQ4YQI6bB%2B3Nf6Wd3lv9UvSElGYQZG%2Fn%2B1KbThhab3oI%2FF%2FOoo2X1bBcBLY%2BEPbSoE5c3t00o%2FiPPNA5IHk0QLaNnuWBKhuve7fM3%2BBSfE%2FPVc9BDLM8WFzC3m09vs9Q%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              },
+              "NEL": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+              },
+              "Server": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "cloudflare"
+              },
+              "CF-RAY": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "7f0f3dabca1d82b0-IAD"
+              },
+              "Content-Encoding": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "br"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string"
+                    },
+                    "start_time": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "end_time": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "pads_created": {
+                      "type": "integer"
+                    },
+                    "users": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "email": {
+                            "type": "string",
+                            "format": "email"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "pads_created": {
+                            "type": "integer"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "status": "OK",
+                  "start_time": "2023-07-27T07:27:21.613-07:00",
+                  "end_time": "2023-08-03T14:27:21.613+00:00",
+                  "pads_created": 107,
+                  "users": [
+                    {
+                      "email": "travis.taylor@coderpad.io",
+                      "name": "travis.taylor",
+                      "pads_created": 4
+                    },
+                    {
+                      "email": "cole.carpenter@coderpad.io",
+                      "name": "cole.carpenter",
+                      "pads_created": 1
+                    },
+                    {
+                      "email": "frank.thetank@coderpad.io",
+                      "name": "frank.thetank",
+                      "pads_created": 9
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "tags": ["v1.0", "Organization"],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "description": "This endpoint returns statistics about how many pads the members of your organization have created. By default the endpoint will return information about the last 7 days, but you can configure the time range as well.\n\n| Parameter | Values |\n| --- | --- |\n| start_time | `datetime` An [ISO 8601 time string](http://www.w3.org/TR/NOTE-datetime), specifying the start of the search window. If this parameter is specified, you must set `end_time` as well, and vice versa. |\n| end_time | `datetime` An ISO 8601 time string specifying the end of the search window. |\n\n```\ncurl \\\n  -H 'Authorization: Token token=\"8af9a3412559d803707937250dc1569d\"' \\\n  \"https://app.coderpad.io/api/organization/stats?\\\nstart_time=2015-12-07T00:31:52Z&\\\nend_time=2015-12-15T00:31:52Z\"\n\n ```\n\nreturns\n\n``` json\n{\n  status: \"OK\",\n  // The computed start/end times are always returned,\n  // even with the default window\n  start_time: 2023-07-23T12:27:05Z,\n  end_time: 2023-07-31T12:27:05Z,\n  pads_created: 137,\n  users: [\n    {\n      email: \"person@place.com\",\n      name: \"Person Surname\",\n      pads_created: 7\n    },\n    {\n      email: \"confidant@place.com\",\n      name: \"Confidant Methodical\",\n      pads_created: 0\n    },\n    // ... followed by the rest of the users in your org\n  ]\n}\n\n ```"
+      }
+    },
+    "/api/organization/pads": {
+      "get": {
+        "summary": "Retrieve pad info for entire company",
+        "responses": {
+          "200": {
+            "description": "Successful request",
+            "headers": {
+              "Date": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Thu, 03 Aug 2023 14:55:01 GMT"
+              },
+              "Transfer-Encoding": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "chunked"
+              },
+              "Connection": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "keep-alive"
+              },
+              "X-Frame-Options": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "SAMEORIGIN"
+              },
+              "X-Xss-Protection": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "1; mode=block"
+              },
+              "X-Content-Type-Options": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "nosniff"
+              },
+              "X-Download-Options": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "noopen"
+              },
+              "X-Permitted-Cross-Domain-Policies": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "none"
+              },
+              "Referrer-Policy": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "strict-origin-when-cross-origin"
+              },
+              "X-Ua-Compatible": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "IE=edge"
+              },
+              "Strict-Transport-Security": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "max-age=31536000; includeSubDomains; preload"
+              },
+              "Vary": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Accept, Accept-Encoding, Origin"
+              },
+              "X-Robots-Tag": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "none"
+              },
+              "Etag": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "W/\"8ecdc2a0b8e3ac8dce973c3d51454408\""
+              },
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "max-age=0, private, must-revalidate"
+              },
+              "Content-Security-Policy": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "default-src 'self' https: blob:; connect-src 'self' ws: https: wss: file: https://edge.fullstory.com https://rs.fullstory.com https://sentry.io; img-src 'self' https: data: http: blob: https://www.googletagmanager.com https://rs.fullstory.com; object-src 'none'; script-src 'self' https: https://*.firebaseio.com https://www.googletagmanager.com https://edge.fullstory.com https://rs.fullstory.com https://js.hs-analytics.net https://www.google-analytics.com https://connect.facebook.net https://widget.intercom.io 'unsafe-inline' 'unsafe-eval'; worker-src 'self' https: blob:; style-src 'self' https: blob: 'unsafe-inline' 'unsafe-eval'; media-src 'self' https: data: blob:; font-src 'self' https: data: chrome-extension moz-extension https://fonts.gstatic.com http://themes.googleusercontent.com; report-uri /csp-report"
+              },
+              "X-Request-Id": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "7b9e4c6f-4180-4aae-8f32-f9fd85869a4a"
+              },
+              "X-Runtime": {
+                "schema": {
+                  "type": "number"
+                },
+                "example": "0.955549"
+              },
+              "Via": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "1.1 vegur"
+              },
+              "CF-Cache-Status": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "DYNAMIC"
+              },
+              "Report-To": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=2O%2FYL0xT2PfUzvZkOdLEC1Zv9r8E8qK6pxC2O3JUnwvuUfhdoaEyBSkTm2WtKpWMKckdUwfn72C42aZdDwUC1kJk8DF0pdogiWOJ1Cj14jKY0n50E4nC2p4djU8A5fy6Kg%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              },
+              "NEL": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+              },
+              "Server": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "cloudflare"
+              },
+              "CF-RAY": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "7f0f66290d3c57e8-IAD"
+              },
+              "Content-Encoding": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "br"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string"
+                    },
+                    "pads": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "state": {
+                            "type": "string"
+                          },
+                          "owner_email": {
+                            "type": "string",
+                            "format": "email"
+                          },
+                          "language": {
+                            "type": "null"
+                          },
+                          "private": {
+                            "type": "boolean"
+                          },
+                          "execution_enabled": {
+                            "type": "boolean"
+                          },
+                          "contents": {
+                            "type": "null"
+                          },
+                          "participants": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "events": {
+                            "type": "string",
+                            "format": "uri"
+                          },
+                          "notes": {
+                            "type": "string"
+                          },
+                          "created_at": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "updated_at": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "ended_at": {
+                            "type": "null"
+                          },
+                          "url": {
+                            "type": "string",
+                            "format": "uri"
+                          },
+                          "playback": {
+                            "type": "string",
+                            "format": "uri"
+                          },
+                          "history": {
+                            "type": "string",
+                            "format": "uri"
+                          },
+                          "drawing": {
+                            "type": "null"
+                          },
+                          "type": {
+                            "type": "string"
+                          },
+                          "question_ids": {
+                            "type": "array",
+                            "items": {
+                              "type": "integer"
+                            }
+                          },
+                          "pad_environment_ids": {
+                            "type": "array",
+                            "items": {
+                              "type": "integer"
+                            }
+                          },
+                          "active_environment_id": {
+                            "type": "integer"
+                          },
+                          "team": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "next_page": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "total": {
+                      "type": "integer"
+                    }
+                  }
+                },
+                "example": {
+                  "status": "OK",
+                  "pads": [
+                    {
+                      "id": "ABC1234",
+                      "title": "Untitled Pad - ABC1234",
+                      "state": "started",
+                      "owner_email": "some.user@coderpad.io",
+                      "language": null,
+                      "private": false,
+                      "execution_enabled": true,
+                      "contents": null,
+                      "participants": ["Loick", "Candidate Luke", "some.user"],
+                      "events": "https://app.coderpad.io/api/pads/ABC1234/events",
+                      "notes": "Here is where our private notes will live\n",
+                      "created_at": "2023-08-03T14:46:43Z",
+                      "updated_at": "2023-08-03T14:53:58Z",
+                      "ended_at": null,
+                      "url": "https://coderpad.io/ABC1234",
+                      "playback": "https://coderpad.io/ABC1234/playback",
+                      "history": "https://coderpad-10.firebaseio.com/ABC1234/history.json",
+                      "drawing": null,
+                      "type": "live",
+                      "question_ids": [9876543],
+                      "pad_environment_ids": [1234567, 2345678],
+                      "active_environment_id": 2345678,
+                      "team": {
+                        "id": "ddc4ce0a-93ec-4bad-9a1a-3d2db96f6220",
+                        "name": "Third Team"
+                      }
+                    },
+                    {
+                      "id": "XYZ4567",
+                      "title": "Untitled Pad - XYZ4567",
+                      "state": "pending",
+                      "owner_email": "chase.bailkin@coderpad.io",
+                      "language": null,
+                      "private": false,
+                      "execution_enabled": true,
+                      "contents": null,
+                      "participants": ["chase.bailkin"],
+                      "events": "https://app.coderpad.io/api/pads/XYZ4567/events",
+                      "notes": "",
+                      "created_at": "2023-08-03T14:22:53Z",
+                      "updated_at": "2023-08-03T14:37:08Z",
+                      "ended_at": null,
+                      "url": "https://coderpad.io/XYZ4567",
+                      "playback": "https://coderpad.io/XYZ4567/playback",
+                      "history": "https://coderpad-4.firebaseio.com/XYZ4567/history.json",
+                      "drawing": null,
+                      "type": "live",
+                      "question_ids": [253253],
+                      "pad_environment_ids": [5556666, 6667777],
+                      "active_environment_id": 6667777,
+                      "team": {
+                        "id": "68264172-5a54-4ac3-962b-cb8d1ad15d05",
+                        "name": "Main Team"
+                      }
+                    }
+                  ],
+                  "next_page": "https://app.coderpad.io/api/organization/pads?page=2",
+                  "total": 50
+                }
+              }
+            }
+          }
+        },
+        "tags": ["v1.0", "Organization"],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "description": "This endpoint is similar to the _Get a list of pads_ operation, except that it returns all the pads in your organization. To access this endpoint, your user must be an organization owner, or your organization must allow all pads to be visible to its users. This last setting is default on, but you can [email us](https://mailto:support@coderpad.io) to disable this feature.\n\nThe endpoint also performs sorting and pagination identically to _Get a list of pads_.\n\n```\ncurl \\\n  -H 'Authorization: Token token=\"8af9a3412559d803707937250dc1569d\"' \\\n  \"https://app.coderpad.io/api/organization/pads?sort=updated_at,desc\"\n\n ```\n\nreturns\n\n``` json\n{\n  \"status\": \"OK\",\n  \"pads\": [\n    {\n      \"id\": \"PP7J474P\",\n      \"title\": \"JavaScript Test\",\n      \"owner_email\": \"kristin@coderpad.io\",\n      \"language\": \"javascript\",\n      \"participants\": [\"Kristin\", \"Guest 104\"],\n      \"contents\": \"var _ = require('underscore');\\n...\",\n      \"private\": false,\n      \"execution_enabled\": true,\n      \"events\": \"https://app.coderpad.io/api/pads/PP7J474P/events\",\n      \"notes\": \"Brenda did a fantastic job talking through the prompt ...\",\n      \"created_at\": \"2018-02-13T02:06:30Z\",\n      \"updated_at\": \"2018-02-13T06:21:26Z\",\n      \"ended_at\": null,\n      \"url\": \"https://coderpad.io/PP7J474P\",\n      \"playback\": \"https://coderpad.io/PP7J474P/playback\",\n      \"history\": \"https://coderpadproject.firebaseio.com/PP7J474P/history.json\",\n      \"drawing\": \"https://storage.googleapis.com/...\",\n      \"team\": {\n        \"id\": \"68264172-5a54-4ac3-962b-cb8d1ad15d05\",\n        \"name\": \"Main Team\"\n      }\n    }\n    // ... followed by a list of the rest of the pads in the organization\n  ],\n  \"next_page\": \"https://app.coderpad.io/api/organization/pads?sort=updated_at,desc&page=2\",\n  \"total\": 512\n}\n\n ```"
+      }
+    },
+    "/api/organization/questions": {
+      "get": {
+        "summary": "Retrieve question info for entire company",
+        "responses": {
+          "200": {
+            "description": "Successful request",
+            "headers": {
+              "Date": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Thu, 03 Aug 2023 15:03:00 GMT"
+              },
+              "Transfer-Encoding": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "chunked"
+              },
+              "Connection": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "keep-alive"
+              },
+              "X-Frame-Options": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "SAMEORIGIN"
+              },
+              "X-Xss-Protection": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "1; mode=block"
+              },
+              "X-Content-Type-Options": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "nosniff"
+              },
+              "X-Download-Options": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "noopen"
+              },
+              "X-Permitted-Cross-Domain-Policies": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "none"
+              },
+              "Referrer-Policy": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "strict-origin-when-cross-origin"
+              },
+              "X-Ua-Compatible": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "IE=edge"
+              },
+              "Strict-Transport-Security": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "max-age=31536000; includeSubDomains; preload"
+              },
+              "Vary": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Accept, Accept-Encoding, Origin"
+              },
+              "X-Robots-Tag": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "none"
+              },
+              "Etag": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "W/\"bb4ce9284985c17daa700b2721babc75\""
+              },
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "max-age=0, private, must-revalidate"
+              },
+              "Content-Security-Policy": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "default-src 'self' https: blob:; connect-src 'self' ws: https: wss: file: https://edge.fullstory.com https://rs.fullstory.com https://sentry.io; img-src 'self' https: data: http: blob: https://www.googletagmanager.com https://rs.fullstory.com; object-src 'none'; script-src 'self' https: https://*.firebaseio.com https://www.googletagmanager.com https://edge.fullstory.com https://rs.fullstory.com https://js.hs-analytics.net https://www.google-analytics.com https://connect.facebook.net https://widget.intercom.io 'unsafe-inline' 'unsafe-eval'; worker-src 'self' https: blob:; style-src 'self' https: blob: 'unsafe-inline' 'unsafe-eval'; media-src 'self' https: data: blob:; font-src 'self' https: data: chrome-extension moz-extension https://fonts.gstatic.com http://themes.googleusercontent.com; report-uri /csp-report"
+              },
+              "X-Request-Id": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "9e8843ce-6c89-4719-9e5d-d787768f9bee"
+              },
+              "X-Runtime": {
+                "schema": {
+                  "type": "number"
+                },
+                "example": "0.837710"
+              },
+              "Via": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "1.1 vegur"
+              },
+              "CF-Cache-Status": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "DYNAMIC"
+              },
+              "Report-To": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=iCk%2F5UXdqF91NUrDByhrZLUHccaLxMuHvDS6bCTiBKkaRT1NsFx1DgGLAa%2BN%2Fx07A2Vwpb97gZR3YSo5RyHCIjLBO0%2BnGKKesf%2F6GxHE10fBKxEHwfVwaZ2N2n7Oqn7tfw%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              },
+              "NEL": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+              },
+              "Server": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "cloudflare"
+              },
+              "CF-RAY": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "7f0f71e1c9615914-IAD"
+              },
+              "Content-Encoding": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "br"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string"
+                    },
+                    "questions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "owner_email": {
+                            "type": "string",
+                            "format": "email"
+                          },
+                          "language": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "null"
+                          },
+                          "candidate_instructions": {
+                            "type": "array"
+                          },
+                          "contents": {
+                            "type": "null"
+                          },
+                          "shared": {
+                            "type": "boolean"
+                          },
+                          "used": {
+                            "type": "integer"
+                          },
+                          "take_home": {
+                            "type": "boolean"
+                          },
+                          "test_cases_enabled": {
+                            "type": "boolean"
+                          },
+                          "solution": {
+                            "type": "null"
+                          },
+                          "pad_type": {
+                            "type": "string"
+                          },
+                          "is_draft": {
+                            "type": "boolean"
+                          },
+                          "author_name": {
+                            "type": "string"
+                          },
+                          "organization_name": {
+                            "type": "string"
+                          },
+                          "custom_files": {
+                            "type": "array"
+                          },
+                          "created_at": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "updated_at": {
+                            "type": "string",
+                            "format": "date-time"
+                          }
+                        }
+                      }
+                    },
+                    "next_page": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "total": {
+                      "type": "integer"
+                    }
+                  }
+                },
+                "example": {
+                  "status": "OK",
+                  "questions": [
+                    {
+                      "id": 123456,
+                      "title": "Are avocados fruity?",
+                      "owner_email": "ken@coderpad.io",
+                      "language": "ruby",
+                      "description": null,
+                      "candidate_instructions": [],
+                      "contents": null,
+                      "shared": true,
+                      "used": 0,
+                      "take_home": false,
+                      "test_cases_enabled": false,
+                      "solution": null,
+                      "pad_type": "live",
+                      "is_draft": false,
+                      "author_name": "ken",
+                      "organization_name": "CoderPad",
+                      "custom_files": [],
+                      "created_at": "2023-08-03T11:32:56Z",
+                      "updated_at": "2023-08-03T11:32:56Z"
+                    },
+                    {
+                      "id": 654321,
+                      "title": "Copy of multifile TS question test",
+                      "owner_email": "user.person@coderpad.io",
+                      "language": null,
+                      "description": null,
+                      "candidate_instructions": [
+                        {
+                          "instructions": "do some stuff",
+                          "default_visible": true
+                        },
+                        {
+                          "instructions": "do some more stuff",
+                          "default_visible": true
+                        }
+                      ],
+                      "contents": null,
+                      "shared": true,
+                      "used": 2,
+                      "take_home": false,
+                      "test_cases_enabled": false,
+                      "solution": "",
+                      "pad_type": "any",
+                      "is_draft": false,
+                      "author_name": "User Person",
+                      "organization_name": "CoderPad",
+                      "custom_files": [],
+                      "created_at": "2023-07-27T01:39:52Z",
+                      "updated_at": "2023-07-27T01:40:22Z"
+                    },
+                    {
+                      "id": 245678,
+                      "title": "multifile TS question test",
+                      "owner_email": "doug@coderpad.io",
+                      "language": null,
+                      "description": null,
+                      "candidate_instructions": [
+                        {
+                          "instructions": "do some stuff",
+                          "default_visible": true
+                        },
+                        {
+                          "instructions": "do some more stuff",
+                          "default_visible": false
+                        }
+                      ],
+                      "contents": null,
+                      "shared": true,
+                      "used": 3,
+                      "take_home": false,
+                      "test_cases_enabled": false,
+                      "solution": "",
+                      "pad_type": "any",
+                      "is_draft": false,
+                      "author_name": "doug",
+                      "organization_name": "CoderPad",
+                      "custom_files": [],
+                      "created_at": "2023-07-24T15:05:28Z",
+                      "updated_at": "2023-07-24T15:08:46Z"
+                    }
+                  ],
+                  "next_page": "https://app.coderpad.io/api/organization/questions?page=2",
+                  "total": 817
+                }
+              }
+            }
+          }
+        },
+        "tags": ["v1.0", "Organization"],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "description": "This endpoint is similar to [<i>GET /api/questions</i>](#d2fa48b3-dbfe-4b9b-af97-9a4df8562f1e), except that it returns all the questions in your organization visible to you. You’ll see your own questions as well as colleagues’ questions where the `shared` boolean is set to `true`. If you are an organization owner, you can see every question in the organization.\n\nThe endpoint also performs sorting and pagination identically to [<i>GET /api/questions</i>](#d2fa48b3-dbfe-4b9b-af97-9a4df8562f1e).\n\n```\ncurl \\\n  -H 'Authorization: Token token=\"8af9a3412559d803707937250dc1569d\"' \\\n  \"https://app.coderpad.io/api/organization/questions?sort=updated_at,desc\"\n\n ```\n\nreturns\n\n```\n{\n  \"status\": \"OK\",\n  \"questions\": [\n    {\n      \"id\": 12,\n      \"title\": \"Are avocados fruity?\",\n      \"owner_email\": \"alice@fruits-party.io\",\n      \"language\": \"ruby\",\n      \"description\": \"Fruit puzzler round 2?\",\n      \"contents\": \"def is_fruity?(thing);\\\\n  end\\\\n\",\n      \"shared\": true,\n      \"used\": 0,\n      \"created_at\": \"2019-01-28T22:08:09Z\",\n      \"updated_at\": \"2019-01-28T22:08:09Z\"\n    }\n    // ... followed by the rest of the questions in the organization visible to you\n  ],\n  \"next_page\": \"https://app.coderpad.io/api/organization/questions?sort=updated_at,desc&page=2\",\n  \"total\": 256\n}\n\n ```"
+      }
+    },
+    "/api/organization/users": {
+      "get": {
+        "summary": "Retrieve company users",
+        "responses": {
+          "200": {
+            "description": "Successful request",
+            "headers": {
+              "Date": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Thu, 03 Aug 2023 15:03:00 GMT"
+              },
+              "Transfer-Encoding": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "chunked"
+              },
+              "Connection": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "keep-alive"
+              },
+              "X-Frame-Options": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "SAMEORIGIN"
+              },
+              "X-Xss-Protection": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "1; mode=block"
+              },
+              "X-Content-Type-Options": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "nosniff"
+              },
+              "X-Download-Options": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "noopen"
+              },
+              "X-Permitted-Cross-Domain-Policies": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "none"
+              },
+              "Referrer-Policy": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "strict-origin-when-cross-origin"
+              },
+              "X-Ua-Compatible": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "IE=edge"
+              },
+              "Strict-Transport-Security": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "max-age=31536000; includeSubDomains; preload"
+              },
+              "Vary": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Accept, Accept-Encoding, Origin"
+              },
+              "X-Robots-Tag": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "none"
+              },
+              "Etag": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "W/\"bb4ce9284985c17daa700b2721babc75\""
+              },
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "max-age=0, private, must-revalidate"
+              },
+              "Content-Security-Policy": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "default-src 'self' https: blob:; connect-src 'self' ws: https: wss: file: https://edge.fullstory.com https://rs.fullstory.com https://sentry.io; img-src 'self' https: data: http: blob: https://www.googletagmanager.com https://rs.fullstory.com; object-src 'none'; script-src 'self' https: https://*.firebaseio.com https://www.googletagmanager.com https://edge.fullstory.com https://rs.fullstory.com https://js.hs-analytics.net https://www.google-analytics.com https://connect.facebook.net https://widget.intercom.io 'unsafe-inline' 'unsafe-eval'; worker-src 'self' https: blob:; style-src 'self' https: blob: 'unsafe-inline' 'unsafe-eval'; media-src 'self' https: data: blob:; font-src 'self' https: data: chrome-extension moz-extension https://fonts.gstatic.com http://themes.googleusercontent.com; report-uri /csp-report"
+              },
+              "X-Request-Id": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "9e8843ce-6c89-4719-9e5d-d787768f9bee"
+              },
+              "X-Runtime": {
+                "schema": {
+                  "type": "number"
+                },
+                "example": "0.837710"
+              },
+              "Via": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "1.1 vegur"
+              },
+              "CF-Cache-Status": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "DYNAMIC"
+              },
+              "Report-To": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=iCk%2F5UXdqF91NUrDByhrZLUHccaLxMuHvDS6bCTiBKkaRT1NsFx1DgGLAa%2BN%2Fx07A2Vwpb97gZR3YSo5RyHCIjLBO0%2BnGKKesf%2F6GxHE10fBKxEHwfVwaZ2N2n7Oqn7tfw%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              },
+              "NEL": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+              },
+              "Server": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "cloudflare"
+              },
+              "CF-RAY": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "7f0f71e1c9615914-IAD"
+              },
+              "Content-Encoding": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "br"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string"
+                    },
+                    "users": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "email": {
+                            "type": "string",
+                            "format": "email"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "teams": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "status": "OK",
+                  "users": [
+                    {
+                      "email": "user.one@company.io",
+                      "name": "user.one",
+                      "teams": [
+                        "68264172-5a54-4ac3-962b-cb8d1ad15d05",
+                        "4a0f61a3-3013-49f5-9eb7-9f83712a49bf",
+                        "ddc4ce0a-93ec-4bad-9a1a-3d2db96f6220"
+                      ]
+                    },
+                    {
+                      "email": "person.two@company.io",
+                      "name": "person.two",
+                      "teams": ["4a0f61a3-3013-49f5-9eb7-9f83712a49bf"]
+                    },
+                    {
+                      "email": "buddy@company.io",
+                      "name": "Buddy",
+                      "teams": [
+                        "68264172-5a54-4ac3-962b-cb8d1ad15d05",
+                        "ddc4ce0a-93ec-4bad-9a1a-3d2db96f6220"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "tags": ["v1.0", "Organization"],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "description": "This endpoint is similar to [<i>GET /api/organization</i>](#d2fa48b3-dbfe-4b9b-af97-9a4df8562f1e), except that it returns only the users list of that organization. If the `email` attribute is set, it returns only the user corresponding to that email.\n\n```\ncurl \\\n  -H 'Authorization: Token token=\"8af9a3412559d803707937250dc1569d\"' \\\n  \"https://app.coderpad.io/api/organization/pads?email=buddy@company.io\"\n\n ```\n\nreturns\n\n```\n{\n    \"status\": \"OK\",\n    \"users\": [\n        {\n            \"email\": \"buddy@company.io\",\n            \"name\": \"Buddy\",\n            \"teams\": [\n                \"68264172-5a54-4ac3-962b-cb8d1ad15d05\",\n                \"ddc4ce0a-93ec-4bad-9a1a-3d2db96f6220\"\n            ]\n        }\n    ]    \n}\n\n ```"
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "BearerAuth": {
+        "type": "http",
+        "scheme": "bearer"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds the OpenAPI spec exported from https://api.interview.coderpad.io via Postman's export to OpenAPI feature. Includes a doc page explaining how the spec was created, linked from the docs index.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes plus a large new `openapi.json` artifact; primary concern is repo size/churn rather than runtime behavior.
> 
> **Overview**
> Adds the exported OpenAPI 3.1 spec (`openapi.json`) used to generate the library.
> 
> Updates the Sphinx docs to include a new `openapi-spec` page describing the spec’s origin/export method, and links it from `docs/source/index.rst`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59f75f4fbc3a71154df4caffedfaf07414687f76. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->