### PR TITLE
Return domain objects instead of response wrappers

### DIFF
--- a/src/coderpad_api/_dict_types.py
+++ b/src/coderpad_api/_dict_types.py
@@ -139,60 +139,9 @@ class OrganizationStatsUserDict(TypedDict):
     pads_created: int
 
 
-class StatusResponseDict(TypedDict):
-    """A response containing only a status."""
+class QuotaDict(TypedDict):
+    """Quota information."""
 
-    status: str
-
-
-class PadResponseDict(PadDict):
-    """Response for creating or retrieving a single pad."""
-
-    status: str
-
-
-class ListPadsResponseDict(TypedDict):
-    """Response for listing pads."""
-
-    status: str
-    pads: list[PadDict]
-    next_page: str
-    total: int
-
-
-class PadEventsResponseDict(TypedDict):
-    """Response for retrieving pad events."""
-
-    status: str
-    events: list[PadEventDict]
-    total: int
-
-
-class PadEnvironmentResponseDict(PadEnvironmentDict):
-    """Response for retrieving a pad environment."""
-
-    status: str
-
-
-class QuestionResponseDict(QuestionDict):
-    """Response for creating or retrieving a question."""
-
-    status: str
-
-
-class ListQuestionsResponseDict(TypedDict):
-    """Response for listing questions."""
-
-    status: str
-    questions: list[QuestionDict]
-    next_page: str
-    total: int
-
-
-class QuotaResponseDict(TypedDict):
-    """Response for retrieving quota information."""
-
-    status: str
     trial_expires_at: str
     pads_used: int
     quota_reset_at: str
@@ -200,10 +149,9 @@ class QuotaResponseDict(TypedDict):
     overages_enabled: bool
 
 
-class OrganizationResponseDict(TypedDict):
-    """Response for retrieving organization information."""
+class OrganizationDict(TypedDict):
+    """Organization information."""
 
-    status: str
     organization_name: str
     user_count: int
     users: list[OrganizationUserDict]
@@ -213,10 +161,9 @@ class OrganizationResponseDict(TypedDict):
     teams: list[TeamDict]
 
 
-class OrganizationStatsResponseDict(TypedDict):
-    """Response for retrieving organization statistics."""
+class OrganizationStatsDict(TypedDict):
+    """Organization usage statistics."""
 
-    status: str
     start_time: str
     end_time: str
     pads_created: int

--- a/src/coderpad_api/client.py
+++ b/src/coderpad_api/client.py
@@ -3,16 +3,13 @@
 import httpx
 
 from coderpad_api.types import (
-    ListPadsResponse,
-    ListQuestionsResponse,
-    OrganizationResponse,
-    OrganizationStatsResponse,
-    PadEnvironmentResponse,
-    PadEventsResponse,
-    PadResponse,
-    QuestionResponse,
-    QuotaResponse,
-    StatusResponse,
+    Organization,
+    OrganizationStats,
+    Pad,
+    PadEnvironment,
+    PadEvent,
+    Question,
+    Quota,
 )
 
 
@@ -42,7 +39,7 @@ class CoderPadClient:
         *,
         sort: str | None = None,
         page: int | None = None,
-    ) -> ListPadsResponse:
+    ) -> list[Pad]:
         """Retrieve a list of pads.
 
         Args:
@@ -50,8 +47,7 @@ class CoderPadClient:
             page: Page number for pagination.
 
         Returns:
-            The JSON response containing pads, next_page,
-            and total.
+            The list of pads.
         """
         params: dict[str, str | int] = {}
         if sort is not None:
@@ -63,7 +59,8 @@ class CoderPadClient:
             params=params,
         )
         response.raise_for_status()
-        return ListPadsResponse.from_dict(data=response.json())
+        data = response.json()
+        return [Pad.from_dict(data=item) for item in data["pads"]]
 
     def create_pad(
         self,
@@ -72,7 +69,7 @@ class CoderPadClient:
         language: str | None = None,
         contents: str | None = None,
         notes: str | None = None,
-    ) -> PadResponse:
+    ) -> Pad:
         """Create a new pad.
 
         Args:
@@ -82,7 +79,7 @@ class CoderPadClient:
             notes: Private notes for the interviewer.
 
         Returns:
-            The JSON response containing the created pad.
+            The created pad.
         """
         data: dict[str, str] = {}
         if title is not None:
@@ -98,22 +95,22 @@ class CoderPadClient:
             data=data,
         )
         response.raise_for_status()
-        return PadResponse.from_dict(data=response.json())
+        return Pad.from_dict(data=response.json())
 
-    def get_pad(self, *, pad_id: str) -> PadResponse:
+    def get_pad(self, *, pad_id: str) -> Pad:
         """Retrieve a pad by id.
 
         Args:
             pad_id: The id of the pad.
 
         Returns:
-            The JSON response containing the pad details.
+            The pad.
         """
         response = self._client.get(
             url=f"/api/pads/{pad_id}",
         )
         response.raise_for_status()
-        return PadResponse.from_dict(data=response.json())
+        return Pad.from_dict(data=response.json())
 
     def update_pad(
         self,
@@ -125,7 +122,7 @@ class CoderPadClient:
         notes: str | None = None,
         ended: bool | None = None,
         deleted: bool | None = None,
-    ) -> StatusResponse:
+    ) -> None:
         """Modify an existing pad.
 
         Args:
@@ -136,9 +133,6 @@ class CoderPadClient:
             notes: New private notes.
             ended: Set to ``True`` to end the interview.
             deleted: Set to ``True`` to delete the pad.
-
-        Returns:
-            The JSON response.
         """
         data: dict[str, str] = {}
         if title is not None:
@@ -158,7 +152,6 @@ class CoderPadClient:
             data=data,
         )
         response.raise_for_status()
-        return StatusResponse.from_dict(data=response.json())
 
     def get_pad_events(
         self,
@@ -166,7 +159,7 @@ class CoderPadClient:
         pad_id: str,
         sort: str | None = None,
         page: int | None = None,
-    ) -> PadEventsResponse:
+    ) -> list[PadEvent]:
         """Retrieve a list of pad events.
 
         Args:
@@ -175,7 +168,7 @@ class CoderPadClient:
             page: Page number for pagination.
 
         Returns:
-            The JSON response containing events and total.
+            The list of pad events.
         """
         params: dict[str, str | int] = {}
         if sort is not None:
@@ -187,29 +180,27 @@ class CoderPadClient:
             params=params,
         )
         response.raise_for_status()
-        return PadEventsResponse.from_dict(
-            data=response.json(),
-        )
+        data = response.json()
+        return [PadEvent.from_dict(data=item) for item in data["events"]]
 
     def get_pad_environment(
         self,
         *,
         environment_id: str,
-    ) -> PadEnvironmentResponse:
+    ) -> PadEnvironment:
         """Retrieve pad environment information.
 
         Args:
             environment_id: The id of the pad environment.
 
         Returns:
-            The JSON response containing the environment
-            details.
+            The pad environment.
         """
         response = self._client.get(
             url=f"/api/pad_environments/{environment_id}",
         )
         response.raise_for_status()
-        return PadEnvironmentResponse.from_dict(
+        return PadEnvironment.from_dict(
             data=response.json(),
         )
 
@@ -218,7 +209,7 @@ class CoderPadClient:
         *,
         sort: str | None = None,
         page: int | None = None,
-    ) -> ListQuestionsResponse:
+    ) -> list[Question]:
         """Retrieve a list of questions.
 
         Args:
@@ -226,8 +217,7 @@ class CoderPadClient:
             page: Page number for pagination.
 
         Returns:
-            The JSON response containing questions,
-            next_page, and total.
+            The list of questions.
         """
         params: dict[str, str | int] = {}
         if sort is not None:
@@ -239,9 +229,8 @@ class CoderPadClient:
             params=params,
         )
         response.raise_for_status()
-        return ListQuestionsResponse.from_dict(
-            data=response.json(),
-        )
+        data = response.json()
+        return [Question.from_dict(data=item) for item in data["questions"]]
 
     def create_question(
         self,
@@ -251,7 +240,7 @@ class CoderPadClient:
         description: str | None = None,
         contents: str | None = None,
         solution: str | None = None,
-    ) -> QuestionResponse:
+    ) -> Question:
         """Create a new question.
 
         Args:
@@ -263,8 +252,7 @@ class CoderPadClient:
             solution: The solution to the question.
 
         Returns:
-            The JSON response containing the created
-            question.
+            The created question.
         """
         data: dict[str, str] = {
             "title": title,
@@ -281,7 +269,7 @@ class CoderPadClient:
             data=data,
         )
         response.raise_for_status()
-        return QuestionResponse.from_dict(
+        return Question.from_dict(
             data=response.json(),
         )
 
@@ -289,21 +277,20 @@ class CoderPadClient:
         self,
         *,
         question_id: str,
-    ) -> QuestionResponse:
+    ) -> Question:
         """Retrieve a question by id.
 
         Args:
             question_id: The id of the question.
 
         Returns:
-            The JSON response containing the question
-            details.
+            The question.
         """
         response = self._client.get(
             url=f"/api/questions/{question_id}",
         )
         response.raise_for_status()
-        return QuestionResponse.from_dict(
+        return Question.from_dict(
             data=response.json(),
         )
 
@@ -316,7 +303,7 @@ class CoderPadClient:
         description: str | None = None,
         contents: str | None = None,
         solution: str | None = None,
-    ) -> StatusResponse:
+    ) -> None:
         """Modify an existing question.
 
         Args:
@@ -326,9 +313,6 @@ class CoderPadClient:
             description: New description.
             contents: New contents.
             solution: New solution.
-
-        Returns:
-            The JSON response.
         """
         data: dict[str, str] = {}
         if title is not None:
@@ -346,49 +330,43 @@ class CoderPadClient:
             data=data,
         )
         response.raise_for_status()
-        return StatusResponse.from_dict(data=response.json())
 
     def delete_question(
         self,
         *,
         question_id: str,
-    ) -> StatusResponse:
+    ) -> None:
         """Delete a question.
 
         Args:
             question_id: The id of the question.
-
-        Returns:
-            The JSON response.
         """
         response = self._client.delete(
             url=f"/api/questions/{question_id}",
         )
         response.raise_for_status()
-        return StatusResponse.from_dict(data=response.json())
 
-    def get_quota(self) -> QuotaResponse:
+    def get_quota(self) -> Quota:
         """Retrieve quota information.
 
         Returns:
-            The JSON response containing quota details.
+            The quota details.
         """
         response = self._client.get(url="/api/quota")
         response.raise_for_status()
-        return QuotaResponse.from_dict(data=response.json())
+        return Quota.from_dict(data=response.json())
 
-    def get_organization(self) -> OrganizationResponse:
+    def get_organization(self) -> Organization:
         """Retrieve organization information.
 
         Returns:
-            The JSON response containing organization
-            details.
+            The organization details.
         """
         response = self._client.get(
             url="/api/organization",
         )
         response.raise_for_status()
-        return OrganizationResponse.from_dict(
+        return Organization.from_dict(
             data=response.json(),
         )
 
@@ -397,7 +375,7 @@ class CoderPadClient:
         *,
         start_time: str | None = None,
         end_time: str | None = None,
-    ) -> OrganizationStatsResponse:
+    ) -> OrganizationStats:
         """Retrieve pad usage stats for the organization.
 
         Args:
@@ -405,7 +383,7 @@ class CoderPadClient:
             end_time: ISO 8601 end of the search window.
 
         Returns:
-            The JSON response containing usage statistics.
+            The usage statistics.
         """
         params: dict[str, str] = {}
         if start_time is not None:
@@ -417,7 +395,7 @@ class CoderPadClient:
             params=params,
         )
         response.raise_for_status()
-        return OrganizationStatsResponse.from_dict(
+        return OrganizationStats.from_dict(
             data=response.json(),
         )
 
@@ -426,7 +404,7 @@ class CoderPadClient:
         *,
         sort: str | None = None,
         page: int | None = None,
-    ) -> ListPadsResponse:
+    ) -> list[Pad]:
         """Retrieve pads for the entire organization.
 
         Args:
@@ -434,8 +412,7 @@ class CoderPadClient:
             page: Page number for pagination.
 
         Returns:
-            The JSON response containing pads, next_page,
-            and total.
+            The list of pads.
         """
         params: dict[str, str | int] = {}
         if sort is not None:
@@ -447,16 +424,15 @@ class CoderPadClient:
             params=params,
         )
         response.raise_for_status()
-        return ListPadsResponse.from_dict(
-            data=response.json(),
-        )
+        data = response.json()
+        return [Pad.from_dict(data=item) for item in data["pads"]]
 
     def list_organization_questions(
         self,
         *,
         sort: str | None = None,
         page: int | None = None,
-    ) -> ListQuestionsResponse:
+    ) -> list[Question]:
         """Retrieve questions for the entire organization.
 
         Args:
@@ -464,8 +440,7 @@ class CoderPadClient:
             page: Page number for pagination.
 
         Returns:
-            The JSON response containing questions,
-            next_page, and total.
+            The list of questions.
         """
         params: dict[str, str | int] = {}
         if sort is not None:
@@ -477,6 +452,5 @@ class CoderPadClient:
             params=params,
         )
         response.raise_for_status()
-        return ListQuestionsResponse.from_dict(
-            data=response.json(),
-        )
+        data = response.json()
+        return [Question.from_dict(data=item) for item in data["questions"]]

--- a/src/coderpad_api/types.py
+++ b/src/coderpad_api/types.py
@@ -7,22 +7,15 @@ from coderpad_api._dict_types import (
     CandidateInstructionDict,
     CustomFileDict,
     FileContentDict,
-    ListPadsResponseDict,
-    ListQuestionsResponseDict,
-    OrganizationResponseDict,
-    OrganizationStatsResponseDict,
+    OrganizationDict,
+    OrganizationStatsDict,
     OrganizationStatsUserDict,
     OrganizationUserDict,
     PadDict,
     PadEnvironmentDict,
-    PadEnvironmentResponseDict,
     PadEventDict,
-    PadEventsResponseDict,
-    PadResponseDict,
     QuestionDict,
-    QuestionResponseDict,
-    QuotaResponseDict,
-    StatusResponseDict,
+    QuotaDict,
     TeamDict,
     TestCaseDict,
 )
@@ -452,322 +445,9 @@ class OrganizationStatsUser:
 
 
 @dataclass(kw_only=True)
-class StatusResponse:
-    """A response containing only a status."""
+class Quota:
+    """Quota information."""
 
-    status: str
-
-    @classmethod
-    def from_dict(
-        cls,
-        data: StatusResponseDict,
-    ) -> Self:
-        """Create from an API response dictionary.
-
-        Args:
-            data: The dictionary to convert.
-
-        Returns:
-            A new instance.
-        """
-        return cls(status=data["status"])
-
-
-@dataclass(kw_only=True)
-class PadResponse:
-    """Response for creating or retrieving a single pad."""
-
-    status: str
-    id: str
-    title: str
-    state: str
-    owner_email: str
-    language: str | None
-    private: bool
-    execution_enabled: bool
-    contents: str | None
-    participants: list[str]
-    events: str
-    notes: str | None
-    created_at: str
-    updated_at: str
-    ended_at: str | None
-    url: str
-    playback: str
-    drawing: str | None
-    type: str
-    question_ids: list[int]
-    pad_environment_ids: list[int]
-    active_environment_id: int | None
-    team: Team
-    history: str | None = None
-
-    @classmethod
-    def from_dict(
-        cls,
-        data: PadResponseDict,
-    ) -> Self:
-        """Create from an API response dictionary.
-
-        Args:
-            data: The dictionary to convert.
-
-        Returns:
-            A new instance.
-        """
-        return cls(
-            status=data["status"],
-            id=data["id"],
-            title=data["title"],
-            state=data["state"],
-            owner_email=data["owner_email"],
-            language=data.get("language"),
-            private=data["private"],
-            execution_enabled=data["execution_enabled"],
-            contents=data.get("contents"),
-            participants=data["participants"],
-            events=data["events"],
-            notes=data.get("notes"),
-            created_at=data["created_at"],
-            updated_at=data["updated_at"],
-            ended_at=data.get("ended_at"),
-            url=data["url"],
-            playback=data["playback"],
-            drawing=data.get("drawing"),
-            type=data["type"],
-            question_ids=data["question_ids"],
-            pad_environment_ids=data["pad_environment_ids"],
-            active_environment_id=data.get(
-                "active_environment_id",
-            ),
-            team=Team.from_dict(data=data["team"]),
-            history=data.get("history"),
-        )
-
-
-@dataclass(kw_only=True)
-class ListPadsResponse:
-    """Response for listing pads."""
-
-    status: str
-    pads: list[Pad]
-    next_page: str
-    total: int
-
-    @classmethod
-    def from_dict(
-        cls,
-        data: ListPadsResponseDict,
-    ) -> Self:
-        """Create from an API response dictionary.
-
-        Args:
-            data: The dictionary to convert.
-
-        Returns:
-            A new instance.
-        """
-        return cls(
-            status=data["status"],
-            pads=[Pad.from_dict(data=item) for item in data["pads"]],
-            next_page=data["next_page"],
-            total=data["total"],
-        )
-
-
-@dataclass(kw_only=True)
-class PadEventsResponse:
-    """Response for retrieving pad events."""
-
-    status: str
-    events: list[PadEvent]
-    total: int
-
-    @classmethod
-    def from_dict(
-        cls,
-        data: PadEventsResponseDict,
-    ) -> Self:
-        """Create from an API response dictionary.
-
-        Args:
-            data: The dictionary to convert.
-
-        Returns:
-            A new instance.
-        """
-        return cls(
-            status=data["status"],
-            events=[PadEvent.from_dict(data=item) for item in data["events"]],
-            total=data["total"],
-        )
-
-
-@dataclass(kw_only=True)
-class PadEnvironmentResponse:
-    """Response for retrieving a pad environment."""
-
-    status: str
-    id: int
-    pad_id: int
-    question_id: int | None
-    example_question_id: int | None
-    language: str
-    file_contents: list[FileContent]
-    created_at: str
-    updated_at: str
-
-    @classmethod
-    def from_dict(
-        cls,
-        data: PadEnvironmentResponseDict,
-    ) -> Self:
-        """Create from an API response dictionary.
-
-        Args:
-            data: The dictionary to convert.
-
-        Returns:
-            A new instance.
-        """
-        return cls(
-            status=data["status"],
-            id=data["id"],
-            pad_id=data["pad_id"],
-            question_id=data.get("question_id"),
-            example_question_id=data.get(
-                "example_question_id",
-            ),
-            language=data["language"],
-            file_contents=[
-                FileContent.from_dict(data=item)
-                for item in data["file_contents"]
-            ],
-            created_at=data["created_at"],
-            updated_at=data["updated_at"],
-        )
-
-
-@dataclass(kw_only=True)
-class QuestionResponse:
-    """Response for creating or retrieving a question."""
-
-    status: str
-    id: int
-    title: str
-    owner_email: str
-    language: str | None
-    description: str | None
-    candidate_instructions: list[CandidateInstruction]
-    contents: str | None
-    shared: bool
-    used: int
-    take_home: bool
-    test_cases_enabled: bool
-    solution: str | None
-    pad_type: str
-    is_draft: bool
-    author_name: str
-    organization_name: str
-    custom_files: list[CustomFile]
-    created_at: str
-    updated_at: str
-    public_take_home_setting_id: int | None = None
-    contents_for_test_cases: str | None = None
-    test_cases: list[TestCase] | None = None
-
-    @classmethod
-    def from_dict(
-        cls,
-        data: QuestionResponseDict,
-    ) -> Self:
-        """Create from an API response dictionary.
-
-        Args:
-            data: The dictionary to convert.
-
-        Returns:
-            A new instance.
-        """
-        raw_test_cases = data.get("test_cases")
-        return cls(
-            status=data["status"],
-            id=data["id"],
-            title=data["title"],
-            owner_email=data["owner_email"],
-            language=data.get("language"),
-            description=data.get("description"),
-            candidate_instructions=[
-                CandidateInstruction.from_dict(data=item)
-                for item in data["candidate_instructions"]
-            ],
-            contents=data.get("contents"),
-            shared=data["shared"],
-            used=data["used"],
-            take_home=data["take_home"],
-            test_cases_enabled=data["test_cases_enabled"],
-            solution=data.get("solution"),
-            pad_type=data["pad_type"],
-            is_draft=data["is_draft"],
-            author_name=data["author_name"],
-            organization_name=data["organization_name"],
-            custom_files=[
-                CustomFile.from_dict(data=item)
-                for item in data["custom_files"]
-            ],
-            created_at=data["created_at"],
-            updated_at=data["updated_at"],
-            public_take_home_setting_id=data.get(
-                "public_take_home_setting_id",
-            ),
-            contents_for_test_cases=data.get(
-                "contents_for_test_cases",
-            ),
-            test_cases=[
-                TestCase.from_dict(data=item) for item in raw_test_cases
-            ]
-            if raw_test_cases is not None
-            else None,
-        )
-
-
-@dataclass(kw_only=True)
-class ListQuestionsResponse:
-    """Response for listing questions."""
-
-    status: str
-    questions: list[Question]
-    next_page: str
-    total: int
-
-    @classmethod
-    def from_dict(
-        cls,
-        data: ListQuestionsResponseDict,
-    ) -> Self:
-        """Create from an API response dictionary.
-
-        Args:
-            data: The dictionary to convert.
-
-        Returns:
-            A new instance.
-        """
-        return cls(
-            status=data["status"],
-            questions=[
-                Question.from_dict(data=item) for item in data["questions"]
-            ],
-            next_page=data["next_page"],
-            total=data["total"],
-        )
-
-
-@dataclass(kw_only=True)
-class QuotaResponse:
-    """Response for retrieving quota information."""
-
-    status: str
     trial_expires_at: str
     pads_used: int
     quota_reset_at: str
@@ -777,7 +457,7 @@ class QuotaResponse:
     @classmethod
     def from_dict(
         cls,
-        data: QuotaResponseDict,
+        data: QuotaDict,
     ) -> Self:
         """Create from an API response dictionary.
 
@@ -788,7 +468,6 @@ class QuotaResponse:
             A new instance.
         """
         return cls(
-            status=data["status"],
             trial_expires_at=data["trial_expires_at"],
             pads_used=data["pads_used"],
             quota_reset_at=data["quota_reset_at"],
@@ -798,10 +477,9 @@ class QuotaResponse:
 
 
 @dataclass(kw_only=True)
-class OrganizationResponse:
-    """Response for retrieving organization information."""
+class Organization:
+    """Organization information."""
 
-    status: str
     organization_name: str
     user_count: int
     users: list[OrganizationUser]
@@ -813,7 +491,7 @@ class OrganizationResponse:
     @classmethod
     def from_dict(
         cls,
-        data: OrganizationResponseDict,
+        data: OrganizationDict,
     ) -> Self:
         """Create from an API response dictionary.
 
@@ -824,7 +502,6 @@ class OrganizationResponse:
             A new instance.
         """
         return cls(
-            status=data["status"],
             organization_name=data["organization_name"],
             user_count=data["user_count"],
             users=[
@@ -840,10 +517,9 @@ class OrganizationResponse:
 
 
 @dataclass(kw_only=True)
-class OrganizationStatsResponse:
-    """Response for retrieving organization statistics."""
+class OrganizationStats:
+    """Organization usage statistics."""
 
-    status: str
     start_time: str
     end_time: str
     pads_created: int
@@ -852,7 +528,7 @@ class OrganizationStatsResponse:
     @classmethod
     def from_dict(
         cls,
-        data: OrganizationStatsResponseDict,
+        data: OrganizationStatsDict,
     ) -> Self:
         """Create from an API response dictionary.
 
@@ -863,7 +539,6 @@ class OrganizationStatsResponse:
             A new instance.
         """
         return cls(
-            status=data["status"],
             start_time=data["start_time"],
             end_time=data["end_time"],
             pads_created=data["pads_created"],

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -43,7 +43,7 @@ class TestListPads:
     ) -> None:
         """Pads can be listed."""
         result = fixture_coderpad_client.list_pads()
-        assert result.status == "OK"
+        assert isinstance(result, list)
 
     @staticmethod
     def test_list_pads_with_sort(
@@ -53,7 +53,7 @@ class TestListPads:
         result = fixture_coderpad_client.list_pads(
             sort="updated_at,desc",
         )
-        assert result.status == "OK"
+        assert isinstance(result, list)
 
     @staticmethod
     def test_list_pads_with_page(
@@ -61,7 +61,7 @@ class TestListPads:
     ) -> None:
         """Pads can be listed with a page parameter."""
         result = fixture_coderpad_client.list_pads(page=2)
-        assert result.status == "OK"
+        assert isinstance(result, list)
 
 
 class TestCreatePad:
@@ -76,7 +76,7 @@ class TestCreatePad:
             title="Test Pad",
             language="python",
         )
-        assert result.status == "OK"
+        assert result.id
 
     @staticmethod
     def test_create_pad_all_params(
@@ -89,7 +89,7 @@ class TestCreatePad:
             contents="print('hello')",
             notes="Private notes",
         )
-        assert result.status == "OK"
+        assert result.id
 
     @staticmethod
     def test_create_pad_minimal(
@@ -97,7 +97,7 @@ class TestCreatePad:
     ) -> None:
         """A pad can be created with no parameters."""
         result = fixture_coderpad_client.create_pad()
-        assert result.status == "OK"
+        assert result.id
 
 
 class TestGetPad:
@@ -111,7 +111,7 @@ class TestGetPad:
         result = fixture_coderpad_client.get_pad(
             pad_id="ABC1234",
         )
-        assert result.status == "OK"
+        assert result.id
 
 
 class TestUpdatePad:
@@ -122,29 +122,27 @@ class TestUpdatePad:
         fixture_coderpad_client: CoderPadClient,
     ) -> None:
         """A pad can be updated."""
-        result = fixture_coderpad_client.update_pad(
+        fixture_coderpad_client.update_pad(
             pad_id="ABC1234",
             title="Updated Title",
         )
-        assert result.status == "OK"
 
     @staticmethod
     def test_update_pad_no_title(
         fixture_coderpad_client: CoderPadClient,
     ) -> None:
         """A pad can be updated without a title."""
-        result = fixture_coderpad_client.update_pad(
+        fixture_coderpad_client.update_pad(
             pad_id="ABC1234",
             language="python",
         )
-        assert result.status == "OK"
 
     @staticmethod
     def test_update_pad_all_params(
         fixture_coderpad_client: CoderPadClient,
     ) -> None:
         """A pad can be updated with all parameters."""
-        result = fixture_coderpad_client.update_pad(
+        fixture_coderpad_client.update_pad(
             pad_id="ABC1234",
             title="Updated Title",
             language="python",
@@ -153,7 +151,6 @@ class TestUpdatePad:
             ended=True,
             deleted=False,
         )
-        assert result.status == "OK"
 
 
 class TestGetPadEvents:
@@ -167,7 +164,7 @@ class TestGetPadEvents:
         result = fixture_coderpad_client.get_pad_events(
             pad_id="ABC1234",
         )
-        assert result.status == "OK"
+        assert isinstance(result, list)
 
     @staticmethod
     def test_get_pad_events_with_params(
@@ -179,7 +176,7 @@ class TestGetPadEvents:
             sort="created_at,asc",
             page=1,
         )
-        assert result.status == "OK"
+        assert isinstance(result, list)
 
 
 class TestGetPadEnvironment:
@@ -193,7 +190,7 @@ class TestGetPadEnvironment:
         result = fixture_coderpad_client.get_pad_environment(
             environment_id="123",
         )
-        assert result.status == "OK"
+        assert result.id
 
 
 class TestListQuestions:
@@ -205,7 +202,7 @@ class TestListQuestions:
     ) -> None:
         """Questions can be listed."""
         result = fixture_coderpad_client.list_questions()
-        assert result.status == "OK"
+        assert isinstance(result, list)
 
     @staticmethod
     def test_list_questions_with_params(
@@ -216,7 +213,7 @@ class TestListQuestions:
             sort="updated_at,desc",
             page=1,
         )
-        assert result.status == "OK"
+        assert isinstance(result, list)
 
 
 class TestCreateQuestion:
@@ -231,7 +228,7 @@ class TestCreateQuestion:
             title="Test Question",
             language="python",
         )
-        assert result.status == "OK"
+        assert result.id
 
     @staticmethod
     def test_create_question_all_params(
@@ -245,7 +242,7 @@ class TestCreateQuestion:
             contents="def solve(): pass",
             solution="def solve(): return 42",
         )
-        assert result.status == "OK"
+        assert result.id
 
 
 class TestGetQuestion:
@@ -259,7 +256,7 @@ class TestGetQuestion:
         result = fixture_coderpad_client.get_question(
             question_id="123",
         )
-        assert result.status == "OK"
+        assert result.id
 
 
 class TestUpdateQuestion:
@@ -270,29 +267,27 @@ class TestUpdateQuestion:
         fixture_coderpad_client: CoderPadClient,
     ) -> None:
         """A question can be updated."""
-        result = fixture_coderpad_client.update_question(
+        fixture_coderpad_client.update_question(
             question_id="123",
             title="Updated Question",
         )
-        assert result.status == "OK"
 
     @staticmethod
     def test_update_question_no_title(
         fixture_coderpad_client: CoderPadClient,
     ) -> None:
         """A question can be updated without a title."""
-        result = fixture_coderpad_client.update_question(
+        fixture_coderpad_client.update_question(
             question_id="123",
             language="ruby",
         )
-        assert result.status == "OK"
 
     @staticmethod
     def test_update_question_all_params(
         fixture_coderpad_client: CoderPadClient,
     ) -> None:
         """A question can be updated with all parameters."""
-        result = fixture_coderpad_client.update_question(
+        fixture_coderpad_client.update_question(
             question_id="123",
             title="Updated",
             language="ruby",
@@ -300,7 +295,6 @@ class TestUpdateQuestion:
             contents="puts 'hi'",
             solution="puts 'answer'",
         )
-        assert result.status == "OK"
 
 
 class TestDeleteQuestion:
@@ -311,10 +305,9 @@ class TestDeleteQuestion:
         fixture_coderpad_client: CoderPadClient,
     ) -> None:
         """A question can be deleted."""
-        result = fixture_coderpad_client.delete_question(
+        fixture_coderpad_client.delete_question(
             question_id="123",
         )
-        assert result.status == "OK"
 
 
 class TestGetQuota:
@@ -326,7 +319,7 @@ class TestGetQuota:
     ) -> None:
         """Quota information can be retrieved."""
         result = fixture_coderpad_client.get_quota()
-        assert result.status == "OK"
+        assert result.pads_used >= 0
 
 
 class TestGetOrganization:
@@ -338,7 +331,7 @@ class TestGetOrganization:
     ) -> None:
         """Organization information can be retrieved."""
         result = fixture_coderpad_client.get_organization()
-        assert result.status == "OK"
+        assert result.organization_name
 
 
 class TestGetOrganizationStats:
@@ -350,7 +343,7 @@ class TestGetOrganizationStats:
     ) -> None:
         """Organization stats can be retrieved."""
         result = fixture_coderpad_client.get_organization_stats()
-        assert result.status == "OK"
+        assert result.pads_created >= 0
 
     @staticmethod
     def test_get_organization_stats_with_params(
@@ -361,7 +354,7 @@ class TestGetOrganizationStats:
             start_time="2023-07-01T00:00:00Z",
             end_time="2023-07-31T00:00:00Z",
         )
-        assert result.status == "OK"
+        assert result.pads_created >= 0
 
 
 class TestListOrganizationPads:
@@ -373,7 +366,7 @@ class TestListOrganizationPads:
     ) -> None:
         """Organization pads can be listed."""
         result = fixture_coderpad_client.list_organization_pads()
-        assert result.status == "OK"
+        assert isinstance(result, list)
 
     @staticmethod
     def test_list_organization_pads_with_params(
@@ -384,7 +377,7 @@ class TestListOrganizationPads:
             sort="updated_at,desc",
             page=1,
         )
-        assert result.status == "OK"
+        assert isinstance(result, list)
 
 
 class TestListOrganizationQuestions:
@@ -396,7 +389,7 @@ class TestListOrganizationQuestions:
     ) -> None:
         """Organization questions can be listed."""
         result = fixture_coderpad_client.list_organization_questions()
-        assert result.status == "OK"
+        assert isinstance(result, list)
 
     @staticmethod
     def test_list_organization_questions_with_params(
@@ -409,4 +402,4 @@ class TestListOrganizationQuestions:
             sort="updated_at,desc",
             page=1,
         )
-        assert result.status == "OK"
+        assert isinstance(result, list)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -8,22 +8,15 @@ from coderpad_api.types import (
     CandidateInstruction,
     CustomFile,
     FileContent,
-    ListPadsResponse,
-    ListQuestionsResponse,
-    OrganizationResponse,
-    OrganizationStatsResponse,
+    Organization,
+    OrganizationStats,
     OrganizationStatsUser,
     OrganizationUser,
     Pad,
     PadEnvironment,
-    PadEnvironmentResponse,
     PadEvent,
-    PadEventsResponse,
-    PadResponse,
     Question,
-    QuestionResponse,
-    QuotaResponse,
-    StatusResponse,
+    Quota,
     Team,
     TestCase,
 )
@@ -33,22 +26,15 @@ if TYPE_CHECKING:
         CandidateInstructionDict,
         CustomFileDict,
         FileContentDict,
-        ListPadsResponseDict,
-        ListQuestionsResponseDict,
-        OrganizationResponseDict,
-        OrganizationStatsResponseDict,
+        OrganizationDict,
+        OrganizationStatsDict,
         OrganizationStatsUserDict,
         OrganizationUserDict,
         PadDict,
         PadEnvironmentDict,
-        PadEnvironmentResponseDict,
         PadEventDict,
-        PadEventsResponseDict,
-        PadResponseDict,
         QuestionDict,
-        QuestionResponseDict,
-        QuotaResponseDict,
-        StatusResponseDict,
+        QuotaDict,
         TeamDict,
         TestCaseDict,
     )
@@ -151,80 +137,6 @@ _PUBLIC_TAKE_HOME_SETTING_ID = 7
 def _question_dict() -> QuestionDict:
     """Sample QuestionDict."""
     return {
-        "id": 5,
-        "title": "FizzBuzz",
-        "owner_email": "owner@example.com",
-        "language": "python",
-        "description": "Write FizzBuzz",
-        "candidate_instructions": [_candidate_instruction_dict()],
-        "contents": "def fizzbuzz(): ...",
-        "shared": False,
-        "used": 3,
-        "take_home": False,
-        "test_cases_enabled": True,
-        "solution": "def fizzbuzz(): pass",
-        "pad_type": "standard",
-        "is_draft": False,
-        "author_name": "Author",
-        "organization_name": "Org",
-        "custom_files": [_custom_file_dict()],
-        "created_at": "2023-01-01T00:00:00Z",
-        "updated_at": "2023-01-02T00:00:00Z",
-        "public_take_home_setting_id": _PUBLIC_TAKE_HOME_SETTING_ID,
-        "contents_for_test_cases": "test code",
-        "test_cases": [_test_case_dict()],
-    }
-
-
-def _pad_response_dict() -> PadResponseDict:
-    """Sample PadResponseDict."""
-    return {
-        "status": "ok",
-        "id": "pad-1",
-        "title": "Interview",
-        "state": "active",
-        "owner_email": "owner@example.com",
-        "language": "python",
-        "private": True,
-        "execution_enabled": True,
-        "contents": "# code",
-        "participants": ["a@example.com"],
-        "events": "[]",
-        "notes": "Good",
-        "created_at": "2023-01-01T00:00:00Z",
-        "updated_at": "2023-01-02T00:00:00Z",
-        "ended_at": "2023-01-03T00:00:00Z",
-        "url": "https://app.coderpad.io/pad-1",
-        "playback": "https://app.coderpad.io/pad-1/playback",
-        "history": "v1",
-        "drawing": "svg-data",
-        "type": "sandbox",
-        "question_ids": [1, 2],
-        "pad_environment_ids": [10],
-        "active_environment_id": 10,
-        "team": _team_dict(),
-    }
-
-
-def _pad_environment_response_dict() -> PadEnvironmentResponseDict:
-    """Sample PadEnvironmentResponseDict."""
-    return {
-        "status": "ok",
-        "id": 1,
-        "pad_id": 2,
-        "question_id": 3,
-        "example_question_id": 4,
-        "language": "python",
-        "file_contents": [_file_content_dict()],
-        "created_at": "2023-01-01T00:00:00Z",
-        "updated_at": "2023-01-02T00:00:00Z",
-    }
-
-
-def _question_response_dict() -> QuestionResponseDict:
-    """Sample QuestionResponseDict."""
-    return {
-        "status": "ok",
         "id": 5,
         "title": "FizzBuzz",
         "owner_email": "owner@example.com",
@@ -454,178 +366,20 @@ class TestOrganizationStatsUser:
         assert result.pads_created == data["pads_created"]
 
 
-class TestStatusResponse:
-    """Tests for ``StatusResponse``."""
+class TestQuota:
+    """Tests for ``Quota``."""
 
     @staticmethod
     def test_from_dict() -> None:
-        """A StatusResponse can be created from a dictionary."""
-        data: StatusResponseDict = {"status": "ok"}
-        result = StatusResponse.from_dict(data=data)
-        assert result.status == data["status"]
-
-
-class TestPadResponse:
-    """Tests for ``PadResponse``."""
-
-    @staticmethod
-    def test_from_dict() -> None:
-        """A PadResponse can be created from a dictionary."""
-        data = _pad_response_dict()
-        result = PadResponse.from_dict(data=data)
-        assert result.status == data["status"]
-        assert result.id == data["id"]
-        assert result.title == data["title"]
-        assert result.state == data["state"]
-        assert result.owner_email == data["owner_email"]
-        assert result.language == data["language"]
-        assert result.private == data["private"]
-        assert result.execution_enabled == data["execution_enabled"]
-        assert result.contents == data["contents"]
-        assert result.participants == data["participants"]
-        assert result.events == data["events"]
-        assert result.notes == data["notes"]
-        assert result.created_at == data["created_at"]
-        assert result.updated_at == data["updated_at"]
-        assert result.ended_at == data["ended_at"]
-        assert result.url == data["url"]
-        assert result.playback == data["playback"]
-        assert result.history == "v1"
-        assert result.drawing == data["drawing"]
-        assert result.type == data["type"]
-        assert result.question_ids == data["question_ids"]
-        assert result.pad_environment_ids == data["pad_environment_ids"]
-        assert result.active_environment_id == data["active_environment_id"]
-        assert result.team.id == data["team"]["id"]
-
-
-class TestListPadsResponse:
-    """Tests for ``ListPadsResponse``."""
-
-    @staticmethod
-    def test_from_dict() -> None:
-        """A ListPadsResponse can be created from a dictionary."""
-        data: ListPadsResponseDict = {
-            "status": "ok",
-            "pads": [_pad_dict()],
-            "next_page": "page2",
-            "total": 1,
-        }
-        result = ListPadsResponse.from_dict(data=data)
-        assert result.status == data["status"]
-        assert len(result.pads) == len(data["pads"])
-        assert result.next_page == data["next_page"]
-        assert result.total == data["total"]
-
-
-class TestPadEventsResponse:
-    """Tests for ``PadEventsResponse``."""
-
-    @staticmethod
-    def test_from_dict() -> None:
-        """A PadEventsResponse can be created from a dictionary."""
-        data: PadEventsResponseDict = {
-            "status": "ok",
-            "events": [_pad_event_dict()],
-            "total": 1,
-        }
-        result = PadEventsResponse.from_dict(data=data)
-        assert result.status == data["status"]
-        assert len(result.events) == len(data["events"])
-        assert result.total == data["total"]
-
-
-class TestPadEnvironmentResponse:
-    """Tests for ``PadEnvironmentResponse``."""
-
-    @staticmethod
-    def test_from_dict() -> None:
-        """A PadEnvironmentResponse can be created from a dictionary."""
-        data = _pad_environment_response_dict()
-        result = PadEnvironmentResponse.from_dict(data=data)
-        assert result.status == data["status"]
-        assert result.id == data["id"]
-        assert result.pad_id == data["pad_id"]
-        assert result.question_id == data["question_id"]
-        assert result.example_question_id == data["example_question_id"]
-        assert result.language == data["language"]
-        assert len(result.file_contents) == len(data["file_contents"])
-        assert result.created_at == data["created_at"]
-        assert result.updated_at == data["updated_at"]
-
-
-class TestQuestionResponse:
-    """Tests for ``QuestionResponse``."""
-
-    @staticmethod
-    def test_from_dict() -> None:
-        """A QuestionResponse can be created from a dictionary."""
-        data = _question_response_dict()
-        result = QuestionResponse.from_dict(data=data)
-        assert result.status == data["status"]
-        assert result.id == data["id"]
-        assert result.title == data["title"]
-        assert result.owner_email == data["owner_email"]
-        assert result.language == data["language"]
-        assert result.description == data["description"]
-        assert len(result.candidate_instructions) == len(
-            data["candidate_instructions"],
-        )
-        assert result.contents == data["contents"]
-        assert result.shared == data["shared"]
-        assert result.used == data["used"]
-        assert result.take_home == data["take_home"]
-        assert result.test_cases_enabled == data["test_cases_enabled"]
-        assert result.pad_type == data["pad_type"]
-        assert result.is_draft == data["is_draft"]
-        assert result.author_name == data["author_name"]
-        assert result.organization_name == data["organization_name"]
-        assert len(result.custom_files) == len(data["custom_files"])
-        assert result.created_at == data["created_at"]
-        assert result.updated_at == data["updated_at"]
-        assert (
-            result.public_take_home_setting_id == _PUBLIC_TAKE_HOME_SETTING_ID
-        )
-        assert result.contents_for_test_cases == "test code"
-        assert result.test_cases is not None
-        assert len(result.test_cases) == 1
-
-
-class TestListQuestionsResponse:
-    """Tests for ``ListQuestionsResponse``."""
-
-    @staticmethod
-    def test_from_dict() -> None:
-        """A ListQuestionsResponse can be created from a dictionary."""
-        data: ListQuestionsResponseDict = {
-            "status": "ok",
-            "questions": [_question_dict()],
-            "next_page": "page2",
-            "total": 1,
-        }
-        result = ListQuestionsResponse.from_dict(data=data)
-        assert result.status == data["status"]
-        assert len(result.questions) == len(data["questions"])
-        assert result.next_page == data["next_page"]
-        assert result.total == data["total"]
-
-
-class TestQuotaResponse:
-    """Tests for ``QuotaResponse``."""
-
-    @staticmethod
-    def test_from_dict() -> None:
-        """A QuotaResponse can be created from a dictionary."""
-        data: QuotaResponseDict = {
-            "status": "ok",
+        """A Quota can be created from a dictionary."""
+        data: QuotaDict = {
             "trial_expires_at": "2024-01-01T00:00:00Z",
             "pads_used": 10,
             "quota_reset_at": "2024-02-01T00:00:00Z",
             "unlimited": False,
             "overages_enabled": True,
         }
-        result = QuotaResponse.from_dict(data=data)
-        assert result.status == data["status"]
+        result = Quota.from_dict(data=data)
         assert result.trial_expires_at == data["trial_expires_at"]
         assert result.pads_used == data["pads_used"]
         assert result.quota_reset_at == data["quota_reset_at"]
@@ -633,14 +387,13 @@ class TestQuotaResponse:
         assert result.overages_enabled == data["overages_enabled"]
 
 
-class TestOrganizationResponse:
-    """Tests for ``OrganizationResponse``."""
+class TestOrganization:
+    """Tests for ``Organization``."""
 
     @staticmethod
     def test_from_dict() -> None:
-        """An OrganizationResponse can be created from a dictionary."""
-        data: OrganizationResponseDict = {
-            "status": "ok",
+        """An Organization can be created from a dictionary."""
+        data: OrganizationDict = {
             "organization_name": "Acme",
             "user_count": 5,
             "users": [
@@ -651,8 +404,7 @@ class TestOrganizationResponse:
             "single_sign_in_url": "https://sso.example.com",
             "teams": [_team_dict()],
         }
-        result = OrganizationResponse.from_dict(data=data)
-        assert result.status == data["status"]
+        result = Organization.from_dict(data=data)
         assert result.organization_name == data["organization_name"]
         assert result.user_count == data["user_count"]
         assert len(result.users) == len(data["users"])
@@ -667,16 +419,15 @@ class TestOrganizationResponse:
         assert len(result.teams) == len(data["teams"])
 
 
-class TestOrganizationStatsResponse:
-    """Tests for ``OrganizationStatsResponse``."""
+class TestOrganizationStats:
+    """Tests for ``OrganizationStats``."""
 
     @staticmethod
     def test_from_dict() -> None:
-        """An OrganizationStatsResponse can be created from a
+        """An OrganizationStats can be created from a
         dictionary.
         """
-        data: OrganizationStatsResponseDict = {
-            "status": "ok",
+        data: OrganizationStatsDict = {
             "start_time": "2023-01-01T00:00:00Z",
             "end_time": "2023-02-01T00:00:00Z",
             "pads_created": 42,
@@ -688,8 +439,7 @@ class TestOrganizationStatsResponse:
                 },
             ],
         }
-        result = OrganizationStatsResponse.from_dict(data=data)
-        assert result.status == data["status"]
+        result = OrganizationStats.from_dict(data=data)
         assert result.start_time == data["start_time"]
         assert result.end_time == data["end_time"]
         assert result.pads_created == data["pads_created"]


### PR DESCRIPTION
## Summary
- Client methods now return domain objects (`Pad`, `Question`, `PadEnvironment`, `list[Pad]`, `list[PadEvent]`, `list[Question]`) instead of response wrapper types (`PadResponse`, `ListPadsResponse`, etc.)
- Methods that only returned a status (`update_pad`, `update_question`, `delete_question`) now return `None`
- Renamed `QuotaResponse` → `Quota`, `OrganizationResponse` → `Organization`, `OrganizationStatsResponse` → `OrganizationStats`, dropping the `status` field
- Removed all corresponding response wrapper TypedDicts from `_dict_types.py`

## Test plan
- [x] All 47 existing tests pass with updated assertions
- [ ] Verify no downstream consumers rely on the removed response types

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a breaking API change for downstream consumers: many client methods now return plain domain objects/lists (or `None`) and the prior `*Response` wrapper types (and their `status` fields) are removed.
> 
> **Overview**
> **Simplifies the public API surface of `CoderPadClient`** by returning domain objects directly (`Pad`, `Question`, `PadEnvironment`, `Quota`, `Organization`, `OrganizationStats`) and returning plain `list[...]` for list endpoints, instead of `*Response` wrapper types.
> 
> **Removes status-only and wrapper response types**: `update_pad`, `update_question`, and `delete_question` now return `None`, and `Quota`/`Organization`/`OrganizationStats` drop the `status` field; corresponding TypedDict response shapes are removed from `_dict_types.py` and tests are updated to assert against the new return types/fields.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f8603df5d9516de28ff1f0470207b34cc12c0d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->