### PR TITLE
Use SortOrder enum for sort parameter type hints

### DIFF
--- a/src/coderpad_api/client.py
+++ b/src/coderpad_api/client.py
@@ -10,6 +10,7 @@ from coderpad_api.types import (
     PadEvent,
     Question,
     Quota,
+    SortOrder,
 )
 
 
@@ -37,13 +38,13 @@ class CoderPadClient:
     def list_pads(
         self,
         *,
-        sort: str | None = None,
+        sort: SortOrder | None = None,
         page: int | None = None,
     ) -> list[Pad]:
         """Retrieve a list of pads.
 
         Args:
-            sort: Sort order, e.g. ``"updated_at,desc"``.
+            sort: Sort order.
             page: Page number for pagination.
 
         Returns:
@@ -51,7 +52,7 @@ class CoderPadClient:
         """
         params: dict[str, str | int] = {}
         if sort is not None:
-            params["sort"] = sort
+            params["sort"] = sort.value
         if page is not None:
             params["page"] = page
         response = self._client.get(
@@ -157,14 +158,14 @@ class CoderPadClient:
         self,
         *,
         pad_id: str,
-        sort: str | None = None,
+        sort: SortOrder | None = None,
         page: int | None = None,
     ) -> list[PadEvent]:
         """Retrieve a list of pad events.
 
         Args:
             pad_id: The id of the pad.
-            sort: Sort order, e.g. ``"created_at,asc"``.
+            sort: Sort order.
             page: Page number for pagination.
 
         Returns:
@@ -172,7 +173,7 @@ class CoderPadClient:
         """
         params: dict[str, str | int] = {}
         if sort is not None:
-            params["sort"] = sort
+            params["sort"] = sort.value
         if page is not None:
             params["page"] = page
         response = self._client.get(
@@ -207,13 +208,13 @@ class CoderPadClient:
     def list_questions(
         self,
         *,
-        sort: str | None = None,
+        sort: SortOrder | None = None,
         page: int | None = None,
     ) -> list[Question]:
         """Retrieve a list of questions.
 
         Args:
-            sort: Sort order, e.g. ``"updated_at,desc"``.
+            sort: Sort order.
             page: Page number for pagination.
 
         Returns:
@@ -221,7 +222,7 @@ class CoderPadClient:
         """
         params: dict[str, str | int] = {}
         if sort is not None:
-            params["sort"] = sort
+            params["sort"] = sort.value
         if page is not None:
             params["page"] = page
         response = self._client.get(
@@ -402,13 +403,13 @@ class CoderPadClient:
     def list_organization_pads(
         self,
         *,
-        sort: str | None = None,
+        sort: SortOrder | None = None,
         page: int | None = None,
     ) -> list[Pad]:
         """Retrieve pads for the entire organization.
 
         Args:
-            sort: Sort order, e.g. ``"updated_at,desc"``.
+            sort: Sort order.
             page: Page number for pagination.
 
         Returns:
@@ -416,7 +417,7 @@ class CoderPadClient:
         """
         params: dict[str, str | int] = {}
         if sort is not None:
-            params["sort"] = sort
+            params["sort"] = sort.value
         if page is not None:
             params["page"] = page
         response = self._client.get(
@@ -430,13 +431,13 @@ class CoderPadClient:
     def list_organization_questions(
         self,
         *,
-        sort: str | None = None,
+        sort: SortOrder | None = None,
         page: int | None = None,
     ) -> list[Question]:
         """Retrieve questions for the entire organization.
 
         Args:
-            sort: Sort order, e.g. ``"updated_at,desc"``.
+            sort: Sort order.
             page: Page number for pagination.
 
         Returns:
@@ -444,7 +445,7 @@ class CoderPadClient:
         """
         params: dict[str, str | int] = {}
         if sort is not None:
-            params["sort"] = sort
+            params["sort"] = sort.value
         if page is not None:
             params["page"] = page
         response = self._client.get(

--- a/src/coderpad_api/types.py
+++ b/src/coderpad_api/types.py
@@ -1,5 +1,6 @@
 """Types for the CoderPad Interview API."""
 
+import enum
 from dataclasses import dataclass
 from typing import Self
 
@@ -19,6 +20,15 @@ from coderpad_api._dict_types import (
     TeamDict,
     TestCaseDict,
 )
+
+
+class SortOrder(enum.Enum):
+    """Sort order for list endpoints."""
+
+    CREATED_AT_ASC = "created_at,asc"
+    CREATED_AT_DESC = "created_at,desc"
+    UPDATED_AT_ASC = "updated_at,asc"
+    UPDATED_AT_DESC = "updated_at,desc"
 
 
 @dataclass(kw_only=True)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,6 +3,7 @@
 import respx
 
 from coderpad_api.client import CoderPadClient
+from coderpad_api.types import SortOrder
 
 
 class TestCoderPadClient:
@@ -51,7 +52,7 @@ class TestListPads:
     ) -> None:
         """Pads can be listed with a sort parameter."""
         result = fixture_coderpad_client.list_pads(
-            sort="updated_at,desc",
+            sort=SortOrder.UPDATED_AT_DESC,
         )
         assert isinstance(result, list)
 
@@ -173,7 +174,7 @@ class TestGetPadEvents:
         """Pad events can be retrieved with sort and page."""
         result = fixture_coderpad_client.get_pad_events(
             pad_id="ABC1234",
-            sort="created_at,asc",
+            sort=SortOrder.CREATED_AT_ASC,
             page=1,
         )
         assert isinstance(result, list)
@@ -210,7 +211,7 @@ class TestListQuestions:
     ) -> None:
         """Questions can be listed with sort and page."""
         result = fixture_coderpad_client.list_questions(
-            sort="updated_at,desc",
+            sort=SortOrder.UPDATED_AT_DESC,
             page=1,
         )
         assert isinstance(result, list)
@@ -374,7 +375,7 @@ class TestListOrganizationPads:
     ) -> None:
         """Organization pads can be listed with optional arguments."""
         result = fixture_coderpad_client.list_organization_pads(
-            sort="updated_at,desc",
+            sort=SortOrder.UPDATED_AT_ASC,
             page=1,
         )
         assert isinstance(result, list)
@@ -399,7 +400,7 @@ class TestListOrganizationQuestions:
         arguments.
         """
         result = fixture_coderpad_client.list_organization_questions(
-            sort="updated_at,desc",
+            sort=SortOrder.CREATED_AT_DESC,
             page=1,
         )
         assert isinstance(result, list)


### PR DESCRIPTION
## Summary
- Add `SortOrder` enum with the four valid sort combinations (`created_at`/`updated_at` x `asc`/`desc`)
- Replace `str` type hints on all `sort` parameters with `SortOrder`
- Update tests to use enum values, covering all four variants

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the public client API: `sort` parameters now require `SortOrder` and will break callers passing raw strings at runtime.
> 
> **Overview**
> Replaces free-form string `sort` parameters on list-style client methods with a new `SortOrder` enum and serializes it via `sort.value` when building request params.
> 
> Adds `SortOrder` to `types.py` with the supported `created_at`/`updated_at` x `asc`/`desc` combinations, and updates client tests to use the enum values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92ad71298f8a63c1dfe6b7aea35057dd8c6d1df8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->