### PR TITLE
Add beartype runtime type checking to library source code

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dynamic = [
     "version",
 ]
 dependencies = [
+    "beartype>=0.22.9",
     "httpx>=0.28.0",
 ]
 optional-dependencies.dev = [

--- a/src/coderpad_api/client.py
+++ b/src/coderpad_api/client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import httpx
+from beartype import beartype
 
 from coderpad_api.types import (
     Organization,
@@ -17,6 +18,7 @@ from coderpad_api.types import (
 )
 
 
+@beartype
 class PadsNamespace:
     """Namespace for pad operations."""
 
@@ -201,6 +203,7 @@ class PadsNamespace:
         )
 
 
+@beartype
 class QuestionsNamespace:
     """Namespace for question operations."""
 
@@ -353,6 +356,7 @@ class QuestionsNamespace:
         response.raise_for_status()
 
 
+@beartype
 class OrganizationPadsNamespace:
     """Namespace for organization pad operations."""
 
@@ -391,6 +395,7 @@ class OrganizationPadsNamespace:
         )
 
 
+@beartype
 class OrganizationQuestionsNamespace:
     """Namespace for organization question operations."""
 
@@ -429,6 +434,7 @@ class OrganizationQuestionsNamespace:
         )
 
 
+@beartype
 class OrganizationNamespace:
     """Namespace for organization operations."""
 
@@ -512,6 +518,7 @@ def _set_client(
     namespace._client = client  # pylint: disable=protected-access  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
 
 
+@beartype
 class CoderPadClient:
     """A client for the CoderPad Interview API."""
 

--- a/src/coderpad_api/types.py
+++ b/src/coderpad_api/types.py
@@ -5,6 +5,8 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Self, TypeVar
 
+from beartype import beartype
+
 from coderpad_api._dict_types import (
     CandidateInstructionDict,
     CustomFileDict,
@@ -25,6 +27,7 @@ from coderpad_api._dict_types import (
 _T = TypeVar("_T")
 
 
+@beartype
 class PaginatedList(list[_T]):
     """A list with pagination metadata from the API response."""
 
@@ -57,6 +60,7 @@ class SortOrder(enum.Enum):
     UPDATED_AT_DESC = "updated_at,desc"
 
 
+@beartype
 @dataclass(kw_only=True)
 class Team:
     """A team within an organization."""
@@ -80,6 +84,7 @@ class Team:
         )
 
 
+@beartype
 @dataclass(kw_only=True)
 class Pad:
     """A CoderPad interview pad."""
@@ -147,6 +152,7 @@ class Pad:
         )
 
 
+@beartype
 @dataclass(kw_only=True)
 class PadEvent:
     """An event associated with a pad."""
@@ -181,6 +187,7 @@ class PadEvent:
         )
 
 
+@beartype
 @dataclass(kw_only=True)
 class FileContent:
     """A file within a pad environment."""
@@ -209,6 +216,7 @@ class FileContent:
         )
 
 
+@beartype
 @dataclass(kw_only=True)
 class PadEnvironment:
     """A pad environment."""
@@ -252,6 +260,7 @@ class PadEnvironment:
         )
 
 
+@beartype
 @dataclass(kw_only=True)
 class CandidateInstruction:
     """Instructions shown to a candidate."""
@@ -281,6 +290,7 @@ class CandidateInstruction:
         )
 
 
+@beartype
 @dataclass(kw_only=True)
 class TestCase:
     """A test case for a question."""
@@ -311,6 +321,7 @@ class TestCase:
         )
 
 
+@beartype
 @dataclass(kw_only=True)
 class CustomFile:
     """A custom file attached to a question."""
@@ -343,6 +354,7 @@ class CustomFile:
         )
 
 
+@beartype
 @dataclass(kw_only=True)
 class Question:
     """A CoderPad question."""
@@ -424,6 +436,7 @@ class Question:
         )
 
 
+@beartype
 @dataclass(kw_only=True)
 class OrganizationUser:
     """A user within an organization."""
@@ -452,6 +465,7 @@ class OrganizationUser:
         )
 
 
+@beartype
 @dataclass(kw_only=True)
 class OrganizationStatsUser:
     """A user's pad usage statistics."""
@@ -480,6 +494,7 @@ class OrganizationStatsUser:
         )
 
 
+@beartype
 @dataclass(kw_only=True)
 class Quota:
     """Quota information."""
@@ -512,6 +527,7 @@ class Quota:
         )
 
 
+@beartype
 @dataclass(kw_only=True)
 class Organization:
     """Organization information."""
@@ -552,6 +568,7 @@ class Organization:
         )
 
 
+@beartype
 @dataclass(kw_only=True)
 class OrganizationStats:
     """Organization usage statistics."""


### PR DESCRIPTION
## Summary
- Added `beartype` as a runtime dependency and decorated all public classes in `src/coderpad_api/client.py` and `src/coderpad_api/types.py` with `@beartype` for runtime type validation.
- This gives callers runtime type checking on all public API surfaces, not just in tests.

Closes #21

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new runtime dependency and enforces runtime type checking on core client/model classes, which can introduce new exceptions in previously-tolerated call patterns and adds overhead on hot paths.
> 
> **Overview**
> **Adds runtime type checking across the library’s public API.** Introduces `beartype` as a required dependency and applies `@beartype` to the main API client namespaces in `client.py` and the exported model/types in `types.py` (including `PaginatedList` and dataclasses), enabling runtime validation of arguments/returns.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8122a2b1fecec483d0f640e9474a68ac05d61f68. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->