### PR TITLE
Replace mock call_count assertions with behavioral checks

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,7 +1,5 @@
 """Tests for the CoderPad client."""
 
-import respx
-
 from coderpad_api.client import CoderPadClient
 from coderpad_api.types import PaginatedList, SortOrder
 
@@ -26,13 +24,11 @@ class TestCoderPadClient:
 
     @staticmethod
     def test_mock_api_available(
-        fixture_mock_coderpad_api: respx.MockRouter,
         fixture_coderpad_client: CoderPadClient,
     ) -> None:
         """The mock API fixture provides a working mock router."""
-        assert fixture_mock_coderpad_api.calls.call_count == 0
-        fixture_coderpad_client.pads.list()
-        assert fixture_mock_coderpad_api.calls.call_count == 1
+        result = fixture_coderpad_client.pads.list()
+        assert isinstance(result, PaginatedList)
 
 
 class TestListPads:


### PR DESCRIPTION
## Summary
- Removed `call_count` assertions from `test_mock_api_available` that coupled the test to respx mock internals
- Replaced with a behavioral assertion checking that `pads.list()` returns a `PaginatedList`
- Removed unused `respx` import from `test_client.py`

Closes #31

## Test plan
- [x] All 33 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only changes that remove coupling to `respx` internals; production code paths are untouched.
> 
> **Overview**
> Updates `tests/test_client.py` to stop asserting `respx` mock `call_count` and instead verify behavior by checking that `pads.list()` returns a `PaginatedList`. Also removes the now-unused `respx` import from the test file.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 444b4c32010c49d259874d59a36663a00dd7b9a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->