### PR TITLE
Shorten fixture_coderpad_client to coderpad_client

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,8 +39,8 @@ def _fixture_mock_coderpad_api(  # pyright: ignore[reportUnusedFunction]
         yield mock_router
 
 
-@pytest.fixture(name="fixture_client")
-def _fixture_client(  # pyright: ignore[reportUnusedFunction]
+@pytest.fixture(name="coderpad_client")
+def _fixture_coderpad_client(  # pyright: ignore[reportUnusedFunction]
     fixture_mock_coderpad_api: respx.MockRouter,
 ) -> CoderPadClient:
     """Provide a CoderPad client configured against the mock API."""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -24,10 +24,10 @@ class TestCoderPadClient:
 
     @staticmethod
     def test_mock_api_available(
-        fixture_client: CoderPadClient,
+        coderpad_client: CoderPadClient,
     ) -> None:
         """The mock API fixture provides a working mock router."""
-        result = fixture_client.pads.list()
+        result = coderpad_client.pads.list()
         assert result.total >= 0
 
 
@@ -36,28 +36,28 @@ class TestListPads:
 
     @staticmethod
     def test_list_pads(
-        fixture_client: CoderPadClient,
+        coderpad_client: CoderPadClient,
     ) -> None:
         """Pads can be listed."""
-        result = fixture_client.pads.list()
+        result = coderpad_client.pads.list()
         assert result.total >= 0
 
     @staticmethod
     def test_list_pads_with_sort(
-        fixture_client: CoderPadClient,
+        coderpad_client: CoderPadClient,
     ) -> None:
         """Pads can be listed with a sort parameter."""
-        result = fixture_client.pads.list(
+        result = coderpad_client.pads.list(
             sort=SortOrder.UPDATED_AT_DESC,
         )
         assert result.total >= 0
 
     @staticmethod
     def test_list_pads_with_page(
-        fixture_client: CoderPadClient,
+        coderpad_client: CoderPadClient,
     ) -> None:
         """Pads can be listed with a page parameter."""
-        result = fixture_client.pads.list(page=2)
+        result = coderpad_client.pads.list(page=2)
         assert result.total >= 0
 
 
@@ -66,10 +66,10 @@ class TestCreatePad:
 
     @staticmethod
     def test_create_pad(
-        fixture_client: CoderPadClient,
+        coderpad_client: CoderPadClient,
     ) -> None:
         """A pad can be created."""
-        result = fixture_client.pads.create(
+        result = coderpad_client.pads.create(
             title="Test Pad",
             language="python",
         )
@@ -77,10 +77,10 @@ class TestCreatePad:
 
     @staticmethod
     def test_create_pad_all_params(
-        fixture_client: CoderPadClient,
+        coderpad_client: CoderPadClient,
     ) -> None:
         """A pad can be created with all parameters."""
-        result = fixture_client.pads.create(
+        result = coderpad_client.pads.create(
             title="Test Pad",
             language="python",
             contents="print('hello')",
@@ -90,10 +90,10 @@ class TestCreatePad:
 
     @staticmethod
     def test_create_pad_minimal(
-        fixture_client: CoderPadClient,
+        coderpad_client: CoderPadClient,
     ) -> None:
         """A pad can be created with no parameters."""
-        result = fixture_client.pads.create()
+        result = coderpad_client.pads.create()
         assert result.id
 
 
@@ -102,10 +102,10 @@ class TestGetPad:
 
     @staticmethod
     def test_get_pad(
-        fixture_client: CoderPadClient,
+        coderpad_client: CoderPadClient,
     ) -> None:
         """A pad can be retrieved by id."""
-        result = fixture_client.pads.get(
+        result = coderpad_client.pads.get(
             pad_id="ABC1234",
         )
         assert result.id
@@ -116,30 +116,30 @@ class TestUpdatePad:
 
     @staticmethod
     def test_update_pad(
-        fixture_client: CoderPadClient,
+        coderpad_client: CoderPadClient,
     ) -> None:
         """A pad can be updated."""
-        fixture_client.pads.update(
+        coderpad_client.pads.update(
             pad_id="ABC1234",
             title="Updated Title",
         )
 
     @staticmethod
     def test_update_pad_no_title(
-        fixture_client: CoderPadClient,
+        coderpad_client: CoderPadClient,
     ) -> None:
         """A pad can be updated without a title."""
-        fixture_client.pads.update(
+        coderpad_client.pads.update(
             pad_id="ABC1234",
             language="python",
         )
 
     @staticmethod
     def test_update_pad_all_params(
-        fixture_client: CoderPadClient,
+        coderpad_client: CoderPadClient,
     ) -> None:
         """A pad can be updated with all parameters."""
-        fixture_client.pads.update(
+        coderpad_client.pads.update(
             pad_id="ABC1234",
             title="Updated Title",
             language="python",
@@ -155,20 +155,20 @@ class TestGetPadEvents:
 
     @staticmethod
     def test_get_pad_events(
-        fixture_client: CoderPadClient,
+        coderpad_client: CoderPadClient,
     ) -> None:
         """Pad events can be retrieved."""
-        result = fixture_client.pads.get_events(
+        result = coderpad_client.pads.get_events(
             pad_id="ABC1234",
         )
         assert result.total >= 0
 
     @staticmethod
     def test_get_pad_events_with_params(
-        fixture_client: CoderPadClient,
+        coderpad_client: CoderPadClient,
     ) -> None:
         """Pad events can be retrieved with sort and page."""
-        result = fixture_client.pads.get_events(
+        result = coderpad_client.pads.get_events(
             pad_id="ABC1234",
             sort=SortOrder.CREATED_AT_ASC,
             page=1,
@@ -181,10 +181,10 @@ class TestGetPadEnvironment:
 
     @staticmethod
     def test_get_pad_environment(
-        fixture_client: CoderPadClient,
+        coderpad_client: CoderPadClient,
     ) -> None:
         """A pad environment can be retrieved."""
-        result = fixture_client.pads.get_environment(
+        result = coderpad_client.pads.get_environment(
             environment_id="123",
         )
         assert result.id
@@ -195,18 +195,18 @@ class TestListQuestions:
 
     @staticmethod
     def test_list_questions(
-        fixture_client: CoderPadClient,
+        coderpad_client: CoderPadClient,
     ) -> None:
         """Questions can be listed."""
-        result = fixture_client.questions.list()
+        result = coderpad_client.questions.list()
         assert result.total >= 0
 
     @staticmethod
     def test_list_questions_with_params(
-        fixture_client: CoderPadClient,
+        coderpad_client: CoderPadClient,
     ) -> None:
         """Questions can be listed with sort and page."""
-        result = fixture_client.questions.list(
+        result = coderpad_client.questions.list(
             sort=SortOrder.UPDATED_AT_DESC,
             page=1,
         )
@@ -218,10 +218,10 @@ class TestCreateQuestion:
 
     @staticmethod
     def test_create_question(
-        fixture_client: CoderPadClient,
+        coderpad_client: CoderPadClient,
     ) -> None:
         """A question can be created."""
-        result = fixture_client.questions.create(
+        result = coderpad_client.questions.create(
             title="Test Question",
             language="python",
         )
@@ -229,10 +229,10 @@ class TestCreateQuestion:
 
     @staticmethod
     def test_create_question_all_params(
-        fixture_client: CoderPadClient,
+        coderpad_client: CoderPadClient,
     ) -> None:
         """A question can be created with all parameters."""
-        result = fixture_client.questions.create(
+        result = coderpad_client.questions.create(
             title="Test Question",
             language="python",
             description="A description",
@@ -247,10 +247,10 @@ class TestGetQuestion:
 
     @staticmethod
     def test_get_question(
-        fixture_client: CoderPadClient,
+        coderpad_client: CoderPadClient,
     ) -> None:
         """A question can be retrieved by id."""
-        result = fixture_client.questions.get(
+        result = coderpad_client.questions.get(
             question_id="123",
         )
         assert result.id
@@ -261,30 +261,30 @@ class TestUpdateQuestion:
 
     @staticmethod
     def test_update_question(
-        fixture_client: CoderPadClient,
+        coderpad_client: CoderPadClient,
     ) -> None:
         """A question can be updated."""
-        fixture_client.questions.update(
+        coderpad_client.questions.update(
             question_id="123",
             title="Updated Question",
         )
 
     @staticmethod
     def test_update_question_no_title(
-        fixture_client: CoderPadClient,
+        coderpad_client: CoderPadClient,
     ) -> None:
         """A question can be updated without a title."""
-        fixture_client.questions.update(
+        coderpad_client.questions.update(
             question_id="123",
             language="ruby",
         )
 
     @staticmethod
     def test_update_question_all_params(
-        fixture_client: CoderPadClient,
+        coderpad_client: CoderPadClient,
     ) -> None:
         """A question can be updated with all parameters."""
-        fixture_client.questions.update(
+        coderpad_client.questions.update(
             question_id="123",
             title="Updated",
             language="ruby",
@@ -299,10 +299,10 @@ class TestDeleteQuestion:
 
     @staticmethod
     def test_delete_question(
-        fixture_client: CoderPadClient,
+        coderpad_client: CoderPadClient,
     ) -> None:
         """A question can be deleted."""
-        fixture_client.questions.delete(
+        coderpad_client.questions.delete(
             question_id="123",
         )
 
@@ -312,10 +312,10 @@ class TestGetQuota:
 
     @staticmethod
     def test_get_quota(
-        fixture_client: CoderPadClient,
+        coderpad_client: CoderPadClient,
     ) -> None:
         """Quota information can be retrieved."""
-        result = fixture_client.organization.get_quota()
+        result = coderpad_client.organization.get_quota()
         assert result.pads_used >= 0
 
 
@@ -324,10 +324,10 @@ class TestGetOrganization:
 
     @staticmethod
     def test_get_organization(
-        fixture_client: CoderPadClient,
+        coderpad_client: CoderPadClient,
     ) -> None:
         """Organization information can be retrieved."""
-        result = fixture_client.organization.get()
+        result = coderpad_client.organization.get()
         assert result.organization_name
 
 
@@ -336,18 +336,18 @@ class TestGetOrganizationStats:
 
     @staticmethod
     def test_get_organization_stats(
-        fixture_client: CoderPadClient,
+        coderpad_client: CoderPadClient,
     ) -> None:
         """Organization stats can be retrieved."""
-        result = fixture_client.organization.get_stats()
+        result = coderpad_client.organization.get_stats()
         assert result.pads_created >= 0
 
     @staticmethod
     def test_get_organization_stats_with_params(
-        fixture_client: CoderPadClient,
+        coderpad_client: CoderPadClient,
     ) -> None:
         """Organization stats can be filtered by time range."""
-        result = fixture_client.organization.get_stats(
+        result = coderpad_client.organization.get_stats(
             start_time="2023-07-01T00:00:00Z",
             end_time="2023-07-31T00:00:00Z",
         )
@@ -359,18 +359,18 @@ class TestListOrganizationPads:
 
     @staticmethod
     def test_list_organization_pads(
-        fixture_client: CoderPadClient,
+        coderpad_client: CoderPadClient,
     ) -> None:
         """Organization pads can be listed."""
-        result = fixture_client.organization.pads.list()
+        result = coderpad_client.organization.pads.list()
         assert result.total >= 0
 
     @staticmethod
     def test_list_organization_pads_with_params(
-        fixture_client: CoderPadClient,
+        coderpad_client: CoderPadClient,
     ) -> None:
         """Organization pads can be listed with optional arguments."""
-        result = fixture_client.organization.pads.list(
+        result = coderpad_client.organization.pads.list(
             sort=SortOrder.UPDATED_AT_ASC,
             page=1,
         )
@@ -382,20 +382,20 @@ class TestListOrganizationQuestions:
 
     @staticmethod
     def test_list_organization_questions(
-        fixture_client: CoderPadClient,
+        coderpad_client: CoderPadClient,
     ) -> None:
         """Organization questions can be listed."""
-        result = fixture_client.organization.questions.list()
+        result = coderpad_client.organization.questions.list()
         assert result.total >= 0
 
     @staticmethod
     def test_list_organization_questions_with_params(
-        fixture_client: CoderPadClient,
+        coderpad_client: CoderPadClient,
     ) -> None:
         """Organization questions can be listed with optional
         arguments.
         """
-        result = fixture_client.organization.questions.list(
+        result = coderpad_client.organization.questions.list(
             sort=SortOrder.CREATED_AT_DESC,
             page=1,
         )


### PR DESCRIPTION
## Summary
- Rename the `fixture_coderpad_client` test fixture to `coderpad_client` by using `name="coderpad_client"` in the fixture decorator
- Update all references across `conftest.py` and `test_client.py`

## Test plan
- [x] All 47 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk rename-only change in test fixtures and their usages; no production code paths or API behavior are modified.
> 
> **Overview**
> Renames the pytest fixture providing a mocked `CoderPadClient` from `fixture_coderpad_client` to `coderpad_client`, and updates all test references accordingly in `tests/test_client.py` and `tests/conftest.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ce47baa03f5e80c18d28875b109e3790c9331d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->