### PR TITLE
Add PyPI badge to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-|Build Status|
+|Build Status| |PyPI|
 
 coderpad-api-python
 ===================
@@ -33,4 +33,6 @@ See the `full documentation <https://adamtheturtle.github.io/coderpad-api-python
 
 .. |Build Status| image:: https://github.com/adamtheturtle/coderpad-api-python/actions/workflows/ci.yml/badge.svg?branch=main
    :target: https://github.com/adamtheturtle/coderpad-api-python/actions
+.. |PyPI| image:: https://badge.fury.io/py/coderpad-py.svg
+   :target: https://badge.fury.io/py/coderpad-py
 .. |minimum-python-version| replace:: 3.13


### PR DESCRIPTION
## Summary
- Adds a PyPI version badge (from badge.fury.io) to the README, next to the existing build status badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds a README badge; no runtime or API behavior is affected.
> 
> **Overview**
> Adds a **PyPI version badge** (via `badge.fury.io`) to `README.rst` alongside the existing build status badge, including the corresponding image and target link definitions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be2ebda25ef8dac8e205cbf5d8833161ceecaf54. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->