### PR TITLE
Make API dataclasses frozen

### DIFF
--- a/src/coderpad_api/types.py
+++ b/src/coderpad_api/types.py
@@ -61,7 +61,7 @@ class SortOrder(enum.Enum):
 
 
 @beartype
-@dataclass(kw_only=True)
+@dataclass(frozen=True, kw_only=True)
 class Team:
     """A team within an organization."""
 
@@ -85,7 +85,7 @@ class Team:
 
 
 @beartype
-@dataclass(kw_only=True)
+@dataclass(frozen=True, kw_only=True)
 class Pad:
     """A CoderPad interview pad."""
 
@@ -153,7 +153,7 @@ class Pad:
 
 
 @beartype
-@dataclass(kw_only=True)
+@dataclass(frozen=True, kw_only=True)
 class PadEvent:
     """An event associated with a pad."""
 
@@ -188,7 +188,7 @@ class PadEvent:
 
 
 @beartype
-@dataclass(kw_only=True)
+@dataclass(frozen=True, kw_only=True)
 class FileContent:
     """A file within a pad environment."""
 
@@ -217,7 +217,7 @@ class FileContent:
 
 
 @beartype
-@dataclass(kw_only=True)
+@dataclass(frozen=True, kw_only=True)
 class PadEnvironment:
     """A pad environment."""
 
@@ -261,7 +261,7 @@ class PadEnvironment:
 
 
 @beartype
-@dataclass(kw_only=True)
+@dataclass(frozen=True, kw_only=True)
 class CandidateInstruction:
     """Instructions shown to a candidate."""
 
@@ -291,7 +291,7 @@ class CandidateInstruction:
 
 
 @beartype
-@dataclass(kw_only=True)
+@dataclass(frozen=True, kw_only=True)
 class TestCase:
     """A test case for a question."""
 
@@ -322,7 +322,7 @@ class TestCase:
 
 
 @beartype
-@dataclass(kw_only=True)
+@dataclass(frozen=True, kw_only=True)
 class CustomFile:
     """A custom file attached to a question."""
 
@@ -355,7 +355,7 @@ class CustomFile:
 
 
 @beartype
-@dataclass(kw_only=True)
+@dataclass(frozen=True, kw_only=True)
 class Question:
     """A CoderPad question."""
 
@@ -437,7 +437,7 @@ class Question:
 
 
 @beartype
-@dataclass(kw_only=True)
+@dataclass(frozen=True, kw_only=True)
 class OrganizationUser:
     """A user within an organization."""
 
@@ -466,7 +466,7 @@ class OrganizationUser:
 
 
 @beartype
-@dataclass(kw_only=True)
+@dataclass(frozen=True, kw_only=True)
 class OrganizationStatsUser:
     """A user's pad usage statistics."""
 
@@ -495,7 +495,7 @@ class OrganizationStatsUser:
 
 
 @beartype
-@dataclass(kw_only=True)
+@dataclass(frozen=True, kw_only=True)
 class Quota:
     """Quota information."""
 
@@ -528,7 +528,7 @@ class Quota:
 
 
 @beartype
-@dataclass(kw_only=True)
+@dataclass(frozen=True, kw_only=True)
 class Organization:
     """Organization information."""
 
@@ -569,7 +569,7 @@ class Organization:
 
 
 @beartype
-@dataclass(kw_only=True)
+@dataclass(frozen=True, kw_only=True)
 class OrganizationStats:
     """Organization usage statistics."""
 


### PR DESCRIPTION
## Summary
Adds `frozen=True` to all CoderPad API types in `types.py`, alongside the existing `kw_only=True`. Parsed API responses are immutable DTOs; accidental field assignment is rejected at runtime.

## Testing
`uv run --extra dev pytest tests/` — 47 passed.

## Notes
Interview-question repos were excluded from this pass. `pip-check-reqs` `FoundModule` was skipped because `__post_init__` mutates `filename`.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Makes all API DTOs in `types.py` immutable, which can break any downstream code that mutates these objects after creation. Runtime behavior changes will surface as assignment errors rather than silent mutation.
> 
> **Overview**
> **All CoderPad API DTOs in `types.py` are now immutable.** The PR adds `frozen=True` to the `@dataclass` definitions for API response types (e.g., `Pad`, `Question`, `Organization`, etc.) while keeping `kw_only=True`.
> 
> This enforces that parsed API objects cannot have fields reassigned after construction, turning accidental mutations into runtime errors; parsing (`from_dict`) behavior and field shapes remain unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ded246b5c6a28a83c478e84dbf2485db2ce6d585. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->