### PR TITLE
Remove type: ignore[call-overload] from CandidateInstruction

### DIFF
--- a/src/coderpad_api/types.py
+++ b/src/coderpad_api/types.py
@@ -283,9 +283,8 @@ class CandidateInstruction:
         """
         return cls(
             instructions=data["instructions"],
-            default_visible=data.get(  # type: ignore[call-overload]
-                "default_visible",
-                False,
+            default_visible=(
+                "default_visible" in data and data["default_visible"]
             ),
         )
 


### PR DESCRIPTION
## Summary
- Removes `# type: ignore[call-overload]` from `CandidateInstruction.from_dict` by replacing `data.get("default_visible", False)` with a membership check that satisfies mypy, pyright, and ty without suppressing the error.

## Test plan
- [x] All type checkers pass (mypy, pyright, ty, pyrefly)
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change limited to `CandidateInstruction.from_dict` parsing logic; behavior should be equivalent except for stricter handling of missing `default_visible` while improving type-checker compatibility.
> 
> **Overview**
> Updates `CandidateInstruction.from_dict` in `types.py` to avoid `# type: ignore[call-overload]` by replacing `data.get("default_visible", False)` with an explicit key-membership check (`"default_visible" in data and data["default_visible"]`). This keeps `default_visible` defaulting to `False` when absent while satisfying stricter type checkers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5932bd7c94f4c845cc35b0de0d9c203933fcc1be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->