### PR TITLE
Remove `from __future__ import annotations`

### DIFF
--- a/src/coderpad_api/async_client.py
+++ b/src/coderpad_api/async_client.py
@@ -1,7 +1,5 @@
 """Async CoderPad Interview API client."""
 
-from __future__ import annotations
-
 from http import HTTPStatus
 from typing import Self
 

--- a/src/coderpad_api/client.py
+++ b/src/coderpad_api/client.py
@@ -1,7 +1,5 @@
 """CoderPad Interview API client."""
 
-from __future__ import annotations
-
 from http import HTTPStatus
 from typing import Self
 

--- a/src/coderpad_api/exceptions.py
+++ b/src/coderpad_api/exceptions.py
@@ -1,12 +1,9 @@
 """Custom exception hierarchy for the CoderPad API."""
 
-from __future__ import annotations
-
 from http import HTTPStatus
-from typing import TYPE_CHECKING, ClassVar
+from typing import ClassVar
 
-if TYPE_CHECKING:
-    from coderpad_api.transports import TransportResponse
+from coderpad_api.transports import TransportResponse
 
 
 class CoderPadError(Exception):
@@ -18,7 +15,7 @@ class CoderPadError(Exception):
         content: The response body.
     """
 
-    _registry: ClassVar[dict[int, type[CoderPadError]]] = {}
+    _registry: ClassVar[dict[int, type["CoderPadError"]]] = {}
 
     def __init_subclass__(
         cls,
@@ -56,7 +53,7 @@ class CoderPadError(Exception):
         cls,
         *,
         response: TransportResponse,
-    ) -> CoderPadError:
+    ) -> "CoderPadError":
         """Create the appropriate exception for a response.
 
         Uses the registry to find a specific exception class

--- a/src/coderpad_api/transports.py
+++ b/src/coderpad_api/transports.py
@@ -1,7 +1,5 @@
 """Transport abstractions for the CoderPad Interview API."""
 
-from __future__ import annotations
-
 import json as json_module
 from dataclasses import dataclass
 from http import HTTPStatus

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,9 +1,21 @@
 """Tests for the CoderPad types."""
 
-from __future__ import annotations
-
-from typing import TYPE_CHECKING
-
+from coderpad_api._dict_types import (
+    CandidateInstructionDict,
+    CustomFileDict,
+    FileContentDict,
+    OrganizationDict,
+    OrganizationStatsDict,
+    OrganizationStatsUserDict,
+    OrganizationUserDict,
+    PadDict,
+    PadEnvironmentDict,
+    PadEventDict,
+    QuestionDict,
+    QuotaDict,
+    TeamDict,
+    TestCaseDict,
+)
 from coderpad_api.types import (
     CandidateInstruction,
     CustomFile,
@@ -20,24 +32,6 @@ from coderpad_api.types import (
     Team,
     TestCase,
 )
-
-if TYPE_CHECKING:
-    from coderpad_api._dict_types import (
-        CandidateInstructionDict,
-        CustomFileDict,
-        FileContentDict,
-        OrganizationDict,
-        OrganizationStatsDict,
-        OrganizationStatsUserDict,
-        OrganizationUserDict,
-        PadDict,
-        PadEnvironmentDict,
-        PadEventDict,
-        QuestionDict,
-        QuotaDict,
-        TeamDict,
-        TestCaseDict,
-    )
 
 
 def _team_dict() -> TeamDict:


### PR DESCRIPTION
## Summary
- Remove `from __future__ import annotations` from all files — unnecessary since the project requires Python 3.13+
- Move `TYPE_CHECKING`-guarded imports to regular imports in `exceptions.py` and `test_types.py` since annotations are now evaluated at runtime
- Quote forward self-references in `CoderPadError` class body to avoid `NameError`

## Test plan
- [x] All 110 tests pass
- [x] Ruff, mypy, pyright, ty, and pyrefly all pass via pre-push hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, mostly mechanical typing/import changes with no functional API behavior changes expected; main risk is potential runtime import cycles or `NameError` if any forward references were missed.
> 
> **Overview**
> Drops `from __future__ import annotations` across the client and transport modules and updates typing to be compatible with *runtime-evaluated* annotations.
> 
> Moves previously `TYPE_CHECKING`-guarded imports to real imports (notably `TransportResponse` in `exceptions.py` and dict type imports in `tests/test_types.py`) and quotes forward references in `CoderPadError` (e.g., `_registry` and `from_response` return type) to avoid runtime `NameError`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 72e6698a9474cb3a7d47ac65705d341e4dfbeb5f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->