### PR TITLE
Validate mutually exclusive question parameters

### DIFF
--- a/src/coderpad_api/async_client.py
+++ b/src/coderpad_api/async_client.py
@@ -341,6 +341,12 @@ class AsyncQuestionsNamespace(_AsyncNamespace):
         Returns:
             The created question.
         """
+        if file_contents is not None and contents is not None:
+            msg = "Cannot combine 'file_contents' with 'contents'."
+            raise ValueError(msg)
+        if file_contents is not None and zip_file is not None:
+            msg = "Cannot combine 'file_contents' with 'zip_file'."
+            raise ValueError(msg)
         data: dict[str, str] = {
             "title": title,
             "language": language,
@@ -430,6 +436,12 @@ class AsyncQuestionsNamespace(_AsyncNamespace):
                 files for a multi-file question. Cannot be
                 combined with ``file_contents``.
         """
+        if file_contents is not None and contents is not None:
+            msg = "Cannot combine 'file_contents' with 'contents'."
+            raise ValueError(msg)
+        if file_contents is not None and zip_file is not None:
+            msg = "Cannot combine 'file_contents' with 'zip_file'."
+            raise ValueError(msg)
         data: dict[str, str] = {}
         if title is not None:
             data["title"] = title

--- a/src/coderpad_api/client.py
+++ b/src/coderpad_api/client.py
@@ -338,6 +338,12 @@ class QuestionsNamespace(_Namespace):
         Returns:
             The created question.
         """
+        if file_contents is not None and contents is not None:
+            msg = "Cannot combine 'file_contents' with 'contents'."
+            raise ValueError(msg)
+        if file_contents is not None and zip_file is not None:
+            msg = "Cannot combine 'file_contents' with 'zip_file'."
+            raise ValueError(msg)
         data: dict[str, str] = {
             "title": title,
             "language": language,
@@ -427,6 +433,12 @@ class QuestionsNamespace(_Namespace):
                 files for a multi-file question. Cannot be
                 combined with ``file_contents``.
         """
+        if file_contents is not None and contents is not None:
+            msg = "Cannot combine 'file_contents' with 'contents'."
+            raise ValueError(msg)
+        if file_contents is not None and zip_file is not None:
+            msg = "Cannot combine 'file_contents' with 'zip_file'."
+            raise ValueError(msg)
         data: dict[str, str] = {}
         if title is not None:
             data["title"] = title

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -397,6 +397,52 @@ class TestAsyncCreateQuestion:
         )
         assert result.id
 
+    @staticmethod
+    @pytest.mark.asyncio
+    async def test_create_file_contents_with_contents_error() -> None:
+        """Combining file_contents with contents raises ValueError."""
+        client = AsyncCoderPadClient(api_key="test-key")
+        with pytest.raises(
+            expected_exception=ValueError,
+            match="Cannot combine 'file_contents' with 'contents'",
+        ):
+            await client.questions.create(
+                title="Test",
+                language="python",
+                contents="print('hi')",
+                file_contents=[
+                    QuestionFileContent(
+                        path="main.py",
+                        contents="print('hi')",
+                    ),
+                ],
+            )
+
+    @staticmethod
+    @pytest.mark.asyncio
+    async def test_create_file_contents_with_zip_file_error(
+        tmp_path: Path,
+    ) -> None:
+        """Combining file_contents with zip_file raises ValueError."""
+        client = AsyncCoderPadClient(api_key="test-key")
+        zip_path = tmp_path / "project.zip"
+        zip_path.write_bytes(data=b"PK\x03\x04fake-zip")
+        with pytest.raises(
+            expected_exception=ValueError,
+            match="Cannot combine 'file_contents' with 'zip_file'",
+        ):
+            await client.questions.create(
+                title="Test",
+                language="python",
+                file_contents=[
+                    QuestionFileContent(
+                        path="main.py",
+                        contents="print('hi')",
+                    ),
+                ],
+                zip_file=zip_path,
+            )
+
 
 class TestAsyncGetQuestion:
     """Tests for ``AsyncCoderPadClient.questions.get``."""
@@ -482,6 +528,50 @@ class TestAsyncUpdateQuestion:
             question_id="123",
             zip_file=zip_path,
         )
+
+    @staticmethod
+    @pytest.mark.asyncio
+    async def test_update_file_contents_with_contents_error() -> None:
+        """Combining file_contents with contents raises ValueError."""
+        client = AsyncCoderPadClient(api_key="test-key")
+        with pytest.raises(
+            expected_exception=ValueError,
+            match="Cannot combine 'file_contents' with 'contents'",
+        ):
+            await client.questions.update(
+                question_id="123",
+                contents="print('hi')",
+                file_contents=[
+                    QuestionFileContent(
+                        path="main.py",
+                        contents="print('hi')",
+                    ),
+                ],
+            )
+
+    @staticmethod
+    @pytest.mark.asyncio
+    async def test_update_file_contents_with_zip_file_error(
+        tmp_path: Path,
+    ) -> None:
+        """Combining file_contents with zip_file raises ValueError."""
+        client = AsyncCoderPadClient(api_key="test-key")
+        zip_path = tmp_path / "project.zip"
+        zip_path.write_bytes(data=b"PK\x03\x04fake-zip")
+        with pytest.raises(
+            expected_exception=ValueError,
+            match="Cannot combine 'file_contents' with 'zip_file'",
+        ):
+            await client.questions.update(
+                question_id="123",
+                file_contents=[
+                    QuestionFileContent(
+                        path="main.py",
+                        contents="print('hi')",
+                    ),
+                ],
+                zip_file=zip_path,
+            )
 
 
 class TestAsyncDeleteQuestion:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -594,6 +594,50 @@ class TestCreateQuestion:
         )
         assert result.id
 
+    @staticmethod
+    def test_create_file_contents_with_contents_error() -> None:
+        """Combining file_contents with contents raises ValueError."""
+        client = CoderPadClient(api_key="test-key")
+        with pytest.raises(
+            expected_exception=ValueError,
+            match="Cannot combine 'file_contents' with 'contents'",
+        ):
+            client.questions.create(
+                title="Test",
+                language="python",
+                contents="print('hi')",
+                file_contents=[
+                    QuestionFileContent(
+                        path="main.py",
+                        contents="print('hi')",
+                    ),
+                ],
+            )
+
+    @staticmethod
+    def test_create_file_contents_with_zip_file_error(
+        tmp_path: Path,
+    ) -> None:
+        """Combining file_contents with zip_file raises ValueError."""
+        client = CoderPadClient(api_key="test-key")
+        zip_path = tmp_path / "project.zip"
+        zip_path.write_bytes(data=b"PK\x03\x04fake-zip")
+        with pytest.raises(
+            expected_exception=ValueError,
+            match="Cannot combine 'file_contents' with 'zip_file'",
+        ):
+            client.questions.create(
+                title="Test",
+                language="python",
+                file_contents=[
+                    QuestionFileContent(
+                        path="main.py",
+                        contents="print('hi')",
+                    ),
+                ],
+                zip_file=zip_path,
+            )
+
 
 class TestGetQuestion:
     """Tests for ``CoderPadClient.questions.get``."""
@@ -673,6 +717,48 @@ class TestUpdateQuestion:
             question_id="123",
             zip_file=zip_path,
         )
+
+    @staticmethod
+    def test_update_file_contents_with_contents_error() -> None:
+        """Combining file_contents with contents raises ValueError."""
+        client = CoderPadClient(api_key="test-key")
+        with pytest.raises(
+            expected_exception=ValueError,
+            match="Cannot combine 'file_contents' with 'contents'",
+        ):
+            client.questions.update(
+                question_id="123",
+                contents="print('hi')",
+                file_contents=[
+                    QuestionFileContent(
+                        path="main.py",
+                        contents="print('hi')",
+                    ),
+                ],
+            )
+
+    @staticmethod
+    def test_update_file_contents_with_zip_file_error(
+        tmp_path: Path,
+    ) -> None:
+        """Combining file_contents with zip_file raises ValueError."""
+        client = CoderPadClient(api_key="test-key")
+        zip_path = tmp_path / "project.zip"
+        zip_path.write_bytes(data=b"PK\x03\x04fake-zip")
+        with pytest.raises(
+            expected_exception=ValueError,
+            match="Cannot combine 'file_contents' with 'zip_file'",
+        ):
+            client.questions.update(
+                question_id="123",
+                file_contents=[
+                    QuestionFileContent(
+                        path="main.py",
+                        contents="print('hi')",
+                    ),
+                ],
+                zip_file=zip_path,
+            )
 
 
 class TestDeleteQuestion:


### PR DESCRIPTION
## Summary
- Adds validation that raises `ValueError` when `file_contents` is combined with `contents` or `zip_file` in question `create`/`update` methods
- Applies to both `CoderPadClient` and `AsyncCoderPadClient`
- The docstrings already documented these constraints but they were not enforced

Addresses https://github.com/adamtheturtle/coderpad/pull/58#discussion_r3009667949

## Test plan
- [x] 8 new tests covering all invalid parameter combinations across both clients
- [x] Full test suite passes (125 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new `ValueError` failures for previously-accepted invalid parameter combinations, which may be a breaking change for some callers. Changes are localized to question `create`/`update` input validation and are covered by new tests.
> 
> **Overview**
> **Question creation/update now enforces documented parameter constraints.** `CoderPadClient` and `AsyncCoderPadClient` question `create`/`update` methods now raise `ValueError` if `file_contents` is combined with either `contents` or `zip_file`.
> 
> **Tests added** to assert these invalid combinations fail for both sync and async clients.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 25de9a7aa0d242fabdd207f50d05e97c463bb8fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->