### PR TITLE
Use python language in RST code blocks with mocked API calls

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,14 +17,21 @@ This is tested on Python |minimum-python-version|\+.
 Getting Started
 ---------------
 
-.. code-block:: python3
+.. code-block:: python
+
+   """Example usage."""
+
+   import sys
 
    from coderpad.client import CoderPad
 
    client = CoderPad(api_key="your-api-key")
    pad = client.pads.create(title="Interview", language="python")
-   pads = client.pads.list()
+   sys.stdout.write(pad.title)
+   for listed_pad in client.pads.list():
+       sys.stdout.write(listed_pad.title)
    org = client.organization.get()
+   sys.stdout.write(org.organization_name)
 
 Full Documentation
 ------------------

--- a/conftest.py
+++ b/conftest.py
@@ -1,15 +1,40 @@
 """Setup for Sybil."""
 
+import json
+from collections.abc import Generator
 from doctest import ELLIPSIS
+from pathlib import Path
 
 import pytest
+import respx
 from beartype import beartype
+from openapi_mock import add_openapi_to_respx
 from sybil import Sybil
 from sybil.parsers.rest import (
     ClearNamespaceParser,
     DocTestParser,
     PythonCodeBlockParser,
 )
+
+_OPENAPI_SPEC_PATH = Path(__file__).parent / "openapi.json"
+_BASE_URL = "https://api.interview.coderpad.io"
+
+
+@pytest.fixture(name="mock_coderpad_api")
+def fixture_mock_coderpad_api() -> Generator[respx.MockRouter]:
+    """Provide a respx mock router backed by the OpenAPI spec."""
+    spec_text = _OPENAPI_SPEC_PATH.read_text(encoding="utf-8")
+    openapi_spec: dict[str, object] = json.loads(s=spec_text)
+    with respx.mock(
+        base_url=_BASE_URL,
+        assert_all_called=False,
+    ) as mock_router:
+        add_openapi_to_respx(
+            mock_obj=mock_router,
+            spec=openapi_spec,
+            base_url=_BASE_URL,
+        )
+        yield mock_router
 
 
 @beartype
@@ -27,4 +52,5 @@ pytest_collect_file = Sybil(
         PythonCodeBlockParser(),
     ],
     patterns=["*.rst", "*.py"],
+    fixtures=["mock_coderpad_api"],
 ).pytest()

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,14 +13,21 @@ This is tested on Python |minimum-python-version|\+.
 Usage
 -----
 
-.. code-block:: python3
+.. code-block:: python
+
+   """Example usage."""
+
+   import sys
 
    from coderpad.client import CoderPad
 
    client = CoderPad(api_key="your-api-key")
    pad = client.pads.create(title="Interview", language="python")
-   pads = client.pads.list()
+   sys.stdout.write(pad.title)
+   for listed_pad in client.pads.list():
+       sys.stdout.write(listed_pad.title)
    org = client.organization.get()
+   sys.stdout.write(org.organization_name)
 
 See the :doc:`api-reference` for full usage details.
 


### PR DESCRIPTION
## Summary
- Switch doc code blocks from `python3` to `python` so doccmd-based linters (ruff, pylint, mypy, pyright, vulture, interrogate) check them
- Add real API usage examples with `sys.stdout.write()` to consume return values and avoid unused-variable lint errors
- Add a `mock_coderpad_api` Sybil fixture in root `conftest.py` backed by the OpenAPI spec, so code blocks execute without network calls

## Test plan
- [x] All 119 tests pass (117 existing + 2 Sybil doc tests)
- [x] All doccmd linters pass: ruff, pylint, mypy, pyright, vulture, interrogate
- [x] Pre-commit hooks pass
- [x] Pre-push hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to documentation examples and test/doctest infrastructure, with no production client logic modified.
> 
> **Overview**
> Updates the RST documentation examples to use `python` code blocks and to actively consume returned values (via `sys.stdout.write`) so doc-linting tools and doctests can run cleanly.
> 
> Adds a `mock_coderpad_api` Sybil fixture in `conftest.py` that uses `respx` plus the repo’s `openapi.json` to mock CoderPad API calls, and wires this fixture into Sybil collection so documentation code blocks execute without real network requests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 78acabd56a02105699f8b44cd5166b035c3ece98. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->