### PR TITLE
Lower minimum Python version to 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,13 +18,15 @@ license = "MIT"
 authors = [
     { name = "Adam Dangoor", email = "adamdangoor@gmail.com" },
 ]
-requires-python = ">=3.13"
+requires-python = ">=3.11"
 classifiers = [
     "Development Status :: 1 - Planning",
     "Environment :: Web Environment",
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX",
     "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
 ]
@@ -46,7 +48,7 @@ optional-dependencies.dev = [
     "interrogate==1.7.0",
     "mypy[faster-cache]==1.19.1",
     "mypy-strict-kwargs==2026.1.12",
-    "openapi-mock==2026.3.2",
+    "openapi-mock==2026.3.2; python_version>='3.12'",
     "prek==0.3.8",
     "pydocstringformatter==0.7.5",
     "pydocstyle==6.3",
@@ -68,7 +70,7 @@ optional-dependencies.dev = [
     # use it to lint shell commands in GitHub workflow files.
     "shellcheck-py==0.11.0.1",
     "shfmt-py==3.12.0.2",
-    "sphinx==9.1.0",
+    "sphinx==9.1.0; python_version>='3.12'",
     "sphinx-copybutton==0.5.2",
     "sphinx-lint==1.0.2",
     "sphinx-pyproject==0.3.0",


### PR DESCRIPTION
## Summary
- Lowers `requires-python` from `>=3.13` to `>=3.11` — no source code changes needed since the codebase uses no features newer than 3.11.
- Adds 3.11 and 3.12 trove classifiers.
- Gates `openapi-mock` and `sphinx` dev dependencies with `python_version>='3.12'` markers since they require Python 3.12+.

## Test plan
- [ ] Verify CI passes on all supported Python versions
- [ ] Confirm `uv pip install` resolves cleanly on Python 3.11

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only changes to supported Python versions and dev dependency markers; no runtime code paths are modified.
> 
> **Overview**
> Lowers the project’s minimum supported Python version from `>=3.13` to `>=3.11` and adds trove classifiers for Python `3.11` and `3.12`.
> 
> Updates dev extras so `openapi-mock` and `sphinx` are only installed on Python `>=3.12`, avoiding resolution failures on `3.11`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 10418930316b9978a7afce59e307363038fd728e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->