### PR TITLE
Use request.config.rootpath for OpenAPI spec path

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -3,7 +3,6 @@
 import json
 from collections.abc import Generator
 from doctest import ELLIPSIS
-from pathlib import Path
 
 import pytest
 import respx
@@ -16,14 +15,16 @@ from sybil.parsers.rest import (
     PythonCodeBlockParser,
 )
 
-_OPENAPI_SPEC_PATH = Path(__file__).parent / "openapi.json"
 _BASE_URL = "https://api.interview.coderpad.io"
 
 
 @pytest.fixture(name="mock_coderpad_api")
-def fixture_mock_coderpad_api() -> Generator[respx.MockRouter]:
+def fixture_mock_coderpad_api(
+    request: pytest.FixtureRequest,
+) -> Generator[respx.MockRouter]:
     """Provide a respx mock router backed by the OpenAPI spec."""
-    spec_text = _OPENAPI_SPEC_PATH.read_text(encoding="utf-8")
+    openapi_spec_path = request.config.rootpath / "openapi.json"
+    spec_text = openapi_spec_path.read_text(encoding="utf-8")
     openapi_spec: dict[str, object] = json.loads(s=spec_text)
     with respx.mock(
         base_url=_BASE_URL,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,6 @@
 
 import json
 from collections.abc import Generator
-from pathlib import Path
 
 import pytest
 import respx
@@ -11,14 +10,14 @@ from openapi_mock import add_openapi_to_respx
 from coderpad.async_client import AsyncCoderPad
 from coderpad.client import CoderPad
 
-_OPENAPI_SPEC_PATH = Path(__file__).parent.parent / "openapi.json"
 _BASE_URL = "https://api.interview.coderpad.io"
 
 
 @pytest.fixture(name="openapi_spec")
-def fixture_openapi_spec() -> dict[str, object]:
+def fixture_openapi_spec(request: pytest.FixtureRequest) -> dict[str, object]:
     """Load the OpenAPI spec from the repo."""
-    spec_text = _OPENAPI_SPEC_PATH.read_text(encoding="utf-8")
+    openapi_spec_path = request.config.rootpath / "openapi.json"
+    spec_text = openapi_spec_path.read_text(encoding="utf-8")
     result: dict[str, object] = json.loads(s=spec_text)
     return result
 


### PR DESCRIPTION
## Summary

Replace the module-level `_OPENAPI_SPEC_PATH` constant (using `Path(__file__).parent`) with `request.config.rootpath / "openapi.json"` in both conftest files. This uses pytest's built-in root path resolution instead of manually computing paths relative to `__file__`.

## Test plan

- [x] All 119 tests pass
- [x] Pre-commit hooks pass (ruff, mypy, pyright, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk test-only change that only affects how the OpenAPI spec file is located; main risk is mis-resolving the path in unusual pytest configurations.
> 
> **Overview**
> Switches OpenAPI spec loading in both `conftest.py` files from a module-level `Path(__file__)...` constant to `request.config.rootpath / "openapi.json"`.
> 
> This updates the relevant fixtures (`mock_coderpad_api` and `openapi_spec`) to accept `pytest.FixtureRequest` and removes the `pathlib.Path` dependency, making spec resolution follow pytest’s determined project root.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70d309d8d7eb92b547a6adb92a92a4e283f07813. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->