### PR TITLE
Drop Python 3.11 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     strategy:
       matrix:
-        python-version: ['3.13', '3.14']
+        python-version: ['3.12', '3.13', '3.14']
         platform: [ubuntu-latest, windows-latest]
 
     runs-on: ${{ matrix.platform }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ Changelog
 Next
 ----
 
+- Removed support for Python 3.11.
+
 2026.03.31.1
 ------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,14 +18,13 @@ license = "MIT"
 authors = [
     { name = "Adam Dangoor", email = "adamdangoor@gmail.com" },
 ]
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 classifiers = [
     "Development Status :: 1 - Planning",
     "Environment :: Web Environment",
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
@@ -48,7 +47,7 @@ optional-dependencies.dev = [
     "interrogate==1.7.0",
     "mypy[faster-cache]==1.19.1",
     "mypy-strict-kwargs==2026.1.12",
-    "openapi-mock==2026.3.2; python_version>='3.12'",
+    "openapi-mock==2026.3.2",
     "prek==0.3.8",
     "pydocstringformatter==0.7.5",
     "pydocstyle==6.3",
@@ -70,7 +69,7 @@ optional-dependencies.dev = [
     # use it to lint shell commands in GitHub workflow files.
     "shellcheck-py==0.11.0.1",
     "shfmt-py==3.12.0.2",
-    "sphinx==9.1.0; python_version>='3.12'",
+    "sphinx==9.1.0",
     "sphinx-copybutton==0.5.2",
     "sphinx-lint==1.0.2",
     "sphinx-pyproject==0.3.0",


### PR DESCRIPTION
## Summary
- Bump minimum Python version from 3.11 to 3.12 in `requires-python` and classifiers
- Add Python 3.12 to the CI test matrix
- Remove now-redundant `python_version>='3.12'` markers from `openapi-mock` and `sphinx` dev dependencies
- Update changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration/metadata change, but it will break installs and CI expectations for users still on Python 3.11.
> 
> **Overview**
> **Drops Python 3.11 support** by bumping `requires-python` to `>=3.12` and removing the `3.11` Trove classifier.
> 
> Updates GitHub Actions CI to test `3.12` (alongside `3.13`/`3.14`) and removes now-redundant Python version markers from `openapi-mock` and `sphinx` dev dependencies. The changelog is updated to note the support removal.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 75b6f90533a96a01580cb331426c64ef9e770a84. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->