### PR TITLE
Use pytest-beartype-tests plugin

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -6,7 +6,6 @@ from doctest import ELLIPSIS
 
 import pytest
 import respx
-from beartype import beartype
 from openapi_mock import add_openapi_to_respx
 from sybil import Sybil
 from sybil.parsers.rest import (
@@ -36,14 +35,6 @@ def fixture_mock_coderpad_api(
             base_url=_BASE_URL,
         )
         yield mock_router
-
-
-@beartype
-def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
-    """Apply the beartype decorator to all collected test functions."""
-    for item in items:
-        if isinstance(item, pytest.Function):
-            item.obj = beartype(obj=item.obj)
 
 
 pytest_collect_file = Sybil(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ optional-dependencies.dev = [
     "pyroma==5.0.1",
     "pytest==9.0.3",
     "pytest-asyncio==1.3.0",
+    "pytest-beartype-tests==2026.4.19.1",
     "pytest-cov==7.1.0",
     "pyyaml==6.0.3",
     "respx==0.23.1",
@@ -80,11 +81,13 @@ optional-dependencies.dev = [
     "vulture==2.16",
     "yamlfix==1.19.1",
     "zizmor==1.24.1",
-    "pytest-beartype-tests==2026.4.19.1",
 ]
 optional-dependencies.release = [ "check-wheel-contents==0.6.3" ]
 urls.Documentation = "https://adamtheturtle.github.io/coderpad-api-python/"
 urls.Source = "https://github.com/adamtheturtle/coderpad-api-python"
+
+[dependency-groups]
+dev = []
 
 [tool.setuptools]
 zip-safe = false
@@ -435,6 +438,3 @@ exclude = [ ".venv" ]
 [tool.yamlfix]
 section_whitelines = 1
 whitelines = 1
-
-[dependency-groups]
-dev = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ optional-dependencies.dev = [
     "vulture==2.16",
     "yamlfix==1.19.1",
     "zizmor==1.24.1",
+    "pytest-beartype-tests==2026.4.19.1",
 ]
 optional-dependencies.release = [ "check-wheel-contents==0.6.3" ]
 urls.Documentation = "https://adamtheturtle.github.io/coderpad-api-python/"
@@ -342,7 +343,6 @@ ignore_names = [
     "__aexit__",
     # pytest configuration
     "pytest_collect_file",
-    "pytest_collection_modifyitems",
     "pytest_plugins",
     # pytest fixtures - we name fixtures like this for this purpose
     "_fixture_*",
@@ -435,3 +435,6 @@ exclude = [ ".venv" ]
 [tool.yamlfix]
 section_whitelines = 1
 whitelines = 1
+
+[dependency-groups]
+dev = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ optional-dependencies.dev = [
     "pyroma==5.0.1",
     "pytest==9.0.3",
     "pytest-asyncio==1.3.0",
-    "pytest-beartype-tests==2026.4.19.1",
+    "pytest-beartype-tests",
     "pytest-cov==7.1.0",
     "pyyaml==6.0.3",
     "respx==0.23.1",
@@ -108,6 +108,9 @@ bdist_wheel.universal = true
 #
 # Code to match this is in ``conf.py``.
 version_scheme = "post-release"
+
+[tool.uv]
+sources.pytest-beartype-tests = { git = "https://github.com/adamtheturtle/pytest-beartype-tests.git", rev = "bc81d99" }
 
 [tool.ruff]
 line-length = 79


### PR DESCRIPTION
This PR adds the [`pytest-beartype-tests`](https://github.com/adamtheturtle/pytest-beartype-tests) dev dependency and removes redundant `pytest_collection_modifyitems` / `@beartype` wiring from conftest where it duplicated the plugin.

The plugin registers via `pytest11` and applies `@beartype` to collected test functions, matching the previous local hook behavior (see the [upstream README](https://github.com/adamtheturtle/pytest-beartype-tests)).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: switches test-time `@beartype` application from a local `pytest_collection_modifyitems` hook to an external pytest plugin, with minimal runtime impact outside the test suite.
> 
> **Overview**
> **Test type-check enforcement is now provided by `pytest-beartype-tests` instead of local wiring.**
> 
> Removes the `conftest.py` `pytest_collection_modifyitems` hook (and `beartype` import) that decorated collected test functions, and adds `pytest-beartype-tests` to dev dependencies.
> 
> Adds a `uv` git source pin for the plugin, introduces an empty `[dependency-groups]` section, and updates `vulture` ignore names to drop the removed hook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ef4b26d9b5aaeadc3ce248b5f5e39d841ffe9d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->