### PR TITLE
Pin pytest-beartype-tests to 2026.4.20

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ optional-dependencies.dev = [
     "pyroma==5.0.1",
     "pytest==9.0.3",
     "pytest-asyncio==1.3.0",
-    "pytest-beartype-tests",
+    "pytest-beartype-tests==2026.4.20",
     "pytest-cov==7.1.0",
     "pyyaml==6.0.3",
     "respx==0.23.1",
@@ -110,7 +110,6 @@ bdist_wheel.universal = true
 version_scheme = "post-release"
 
 [tool.uv]
-sources.pytest-beartype-tests = { git = "https://github.com/adamtheturtle/pytest-beartype-tests.git", rev = "bc81d99" }
 
 [tool.ruff]
 line-length = 79

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,8 +109,6 @@ bdist_wheel.universal = true
 # Code to match this is in ``conf.py``.
 version_scheme = "post-release"
 
-[tool.uv]
-
 [tool.ruff]
 line-length = 79
 lint.select = [


### PR DESCRIPTION
Pin `pytest-beartype-tests` to PyPI [`2026.4.20`](https://pypi.org/project/pytest-beartype-tests/2026.4.20/), which includes the Sybil-safe plugin change, and drop the temporary `[tool.uv.sources]` git override.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adjusts dev/test tooling dependencies and removes a git override; no runtime code or production behavior changes.
> 
> **Overview**
> Updates the dev dependency `pytest-beartype-tests` to a pinned PyPI release (`2026.4.20`) instead of an unpinned/externally sourced install.
> 
> Removes the temporary `uv` git source override (`[tool.uv].sources.pytest-beartype-tests`) now that the needed changes are available in the published package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3bc6dd9dbf5917f770f6fa15a14d6ace400e2e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->