### PR TITLE
chore: define uv version once in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,8 @@
 ---
 fail_fast: true
 
+.uv_version: &uv_version uv==0.9.5
+
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 
@@ -101,7 +103,8 @@ repos:
         language: python
         pass_filenames: false
         types_or: [yaml]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: pydocstringformatter
@@ -109,7 +112,8 @@ repos:
         entry: uv run --extra=dev pydocstringformatter
         language: python
         types_or: [python]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: shellcheck
@@ -117,7 +121,8 @@ repos:
         entry: uv run --extra=dev shellcheck --shell=bash
         language: python
         types_or: [shell]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: shellcheck-docs
@@ -126,7 +131,8 @@ repos:
           --language=console --command="shellcheck --shell=bash"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: shfmt
@@ -134,7 +140,8 @@ repos:
         entry: uv run --extra=dev shfmt --write --space-redirects --indent=4
         language: python
         types_or: [shell]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: shfmt-docs
@@ -143,7 +150,8 @@ repos:
           --no-pad-file --command="shfmt --write --space-redirects --indent=4"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: mypy
@@ -153,7 +161,8 @@ repos:
         language: python
         types_or: [python, toml]
         pass_filenames: false
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies:
+          - *uv_version
 
       # We do not use --example-workers 0 due to https://github.com/python/mypy/issues/18283
       - id: mypy-docs
@@ -162,7 +171,8 @@ repos:
         entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies:
+          - *uv_version
 
       - id: check-manifest
         name: check-manifest
@@ -170,7 +180,8 @@ repos:
         entry: uv run --extra=dev -m check_manifest
         language: python
         pass_filenames: false
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies:
+          - *uv_version
 
       - id: pyright
         name: pyright
@@ -179,7 +190,8 @@ repos:
         language: python
         types_or: [python, toml]
         pass_filenames: false
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies:
+          - *uv_version
 
       - id: pyright-docs
         name: pyright-docs
@@ -188,7 +200,8 @@ repos:
           --command="pyright"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies:
+          - *uv_version
 
       - id: vulture
         name: vulture
@@ -196,7 +209,8 @@ repos:
         language: python
         types_or: [python]
         pass_filenames: false
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: vulture-docs
@@ -205,7 +219,8 @@ repos:
           --command="vulture"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: pyroma
@@ -214,7 +229,8 @@ repos:
         language: python
         pass_filenames: false
         types_or: [toml]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: deptry
@@ -222,7 +238,8 @@ repos:
         entry: uv run --extra=dev -m deptry src/
         language: python
         pass_filenames: false
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: pylint
@@ -231,7 +248,8 @@ repos:
         language: python
         stages: [manual]
         pass_filenames: false
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies:
+          - *uv_version
 
       - id: pylint-docs
         name: pylint-docs
@@ -240,14 +258,16 @@ repos:
         language: python
         stages: [manual]
         types_or: [markdown, rst]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies:
+          - *uv_version
 
       - id: ruff-check-fix
         name: Ruff check fix
         entry: uv run --extra=dev -m ruff check --fix
         language: python
         types_or: [python]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: ruff-check-fix-docs
@@ -255,7 +275,8 @@ repos:
         entry: uv run --extra=dev doccmd --language=python --command="ruff check --fix"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: ruff-format-fix
@@ -263,7 +284,8 @@ repos:
         entry: uv run --extra=dev -m ruff format
         language: python
         types_or: [python]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: ruff-format-fix-docs
@@ -272,7 +294,8 @@ repos:
           format"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: doc8
@@ -280,7 +303,8 @@ repos:
         entry: uv run --extra=dev -m doc8
         language: python
         types_or: [rst]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: interrogate
@@ -288,7 +312,8 @@ repos:
         entry: uv run --extra=dev -m interrogate
         language: python
         types_or: [python]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: interrogate-docs
@@ -297,7 +322,8 @@ repos:
           --command="interrogate"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: pyproject-fmt-fix
@@ -306,7 +332,8 @@ repos:
         language: python
         types_or: [toml]
         files: pyproject.toml
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: linkcheck
@@ -317,7 +344,8 @@ repos:
         types_or: [rst]
         stages: [manual]
         pass_filenames: false
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies:
+          - *uv_version
 
       - id: spelling
         name: spelling
@@ -327,7 +355,8 @@ repos:
         types_or: [rst]
         stages: [manual]
         pass_filenames: false
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies:
+          - *uv_version
 
       - id: docs
         name: Build Documentation
@@ -335,7 +364,8 @@ repos:
         language: python
         stages: [manual]
         pass_filenames: false
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies:
+          - *uv_version
 
       - id: pyright-verifytypes
         name: pyright-verifytypes
@@ -344,7 +374,8 @@ repos:
         language: python
         pass_filenames: false
         types_or: [python]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies:
+          - *uv_version
 
       - id: ty
         name: ty
@@ -353,7 +384,8 @@ repos:
         language: python
         types_or: [python, toml]
         pass_filenames: false
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies:
+          - *uv_version
 
       - id: ty-docs
         name: ty-docs
@@ -362,14 +394,16 @@ repos:
           --command="ty check"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies:
+          - *uv_version
 
       - id: yamlfix
         name: yamlfix
         entry: uv run --extra=dev yamlfix
         language: python
         types_or: [yaml]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: zizmor
@@ -378,7 +412,8 @@ repos:
         language: python
         pass_filenames: false
         types_or: [yaml]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: sphinx-lint
@@ -386,7 +421,8 @@ repos:
         entry: uv run --extra=dev sphinx-lint --enable=all --disable=line-too-long
         language: python
         types_or: [rst]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: pyrefly
@@ -396,7 +432,8 @@ repos:
         language: python
         types_or: [python, toml]
         pass_filenames: false
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies:
+          - *uv_version
 
       - id: pyrefly-docs
         name: pyrefly-docs
@@ -405,4 +442,5 @@ repos:
           --command="pyrefly check"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies:
+          - *uv_version


### PR DESCRIPTION
Matches the pattern from [literalizer](https://github.com/adamtheturtle/literalizer): a YAML anchor `.uv_version` so the uv pin is declared once and referenced as `*uv_version` in each hook's `additional_dependencies`.

`pre-commit validate-config` may warn about an unexpected root key `.uv_version`; that is expected and matches literalizer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only refactor that keeps the `uv==0.9.5` pin unchanged; main risk is YAML/root-key compatibility with `pre-commit validate-config` or tooling that rejects unknown top-level keys.
> 
> **Overview**
> Defines a top-level YAML anchor `.uv_version: &uv_version uv==0.9.5` and updates every local pre-commit hook to reference it (`additional_dependencies: [*uv_version]`) instead of repeating the literal version string.
> 
> No hook commands, stages, or the pinned `uv` version change; this is a maintainability refactor of `.pre-commit-config.yaml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68331ad9de23025d7078c273f02c662481c6c791. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->