### PR TITLE
chore: bump uv to 0.11.7 for pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 fail_fast: true
 
-.uv_version: &uv_version uv==0.9.5
+.uv_version: &uv_version uv==0.11.7
 
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks


### PR DESCRIPTION
Bumps the uv pin in `.pre-commit-config.yaml` (`.uv_version` YAML anchor) to **uv 0.11.7**, matching the current [astral-sh/uv](https://github.com/astral-sh/uv) release used for pre-commit local hooks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-version bump for a development tool used by pre-commit hooks; low impact beyond potential hook behavior changes due to the newer `uv` release.
> 
> **Overview**
> Updates the `.uv_version` pin in `.pre-commit-config.yaml` from `uv==0.9.5` to `uv==0.11.7`, affecting the `uv run`-based local pre-commit hooks that rely on this shared dependency version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73d936468ff33a4f12821d93f1e0701610884505. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->