### PR TITLE
Support question_id in PadsNamespace.create

### DIFF
--- a/src/coderpad/async_client.py
+++ b/src/coderpad/async_client.py
@@ -160,7 +160,7 @@ class AsyncPadsNamespace(_AsyncNamespace):
         if notes is not None:
             data["notes"] = notes
         if question_id is not None:
-            data["question_id"] = str(question_id)
+            data["question_id"] = str(object=question_id)
         response = await self._request(
             method="POST",
             url="/api/pads/",

--- a/src/coderpad/async_client.py
+++ b/src/coderpad/async_client.py
@@ -132,6 +132,7 @@ class AsyncPadsNamespace(_AsyncNamespace):
         language: Language | str | None = None,
         contents: str | None = None,
         notes: str | None = None,
+        question_id: str | int | None = None,
     ) -> Pad:
         """Create a new pad.
 
@@ -140,6 +141,8 @@ class AsyncPadsNamespace(_AsyncNamespace):
             language: Programming language for the pad.
             contents: Initial contents of the pad editor.
             notes: Private notes for the interviewer.
+            question_id: Id of an existing question to seed
+                the pad from.
 
         Returns:
             The created pad.
@@ -156,6 +159,8 @@ class AsyncPadsNamespace(_AsyncNamespace):
             data["contents"] = contents
         if notes is not None:
             data["notes"] = notes
+        if question_id is not None:
+            data["question_id"] = str(question_id)
         response = await self._request(
             method="POST",
             url="/api/pads/",

--- a/src/coderpad/client.py
+++ b/src/coderpad/client.py
@@ -132,6 +132,7 @@ class PadsNamespace(_Namespace):
         language: Language | str | None = None,
         contents: str | None = None,
         notes: str | None = None,
+        question_id: str | int | None = None,
     ) -> Pad:
         """Create a new pad.
 
@@ -140,6 +141,8 @@ class PadsNamespace(_Namespace):
             language: Programming language for the pad.
             contents: Initial contents of the pad editor.
             notes: Private notes for the interviewer.
+            question_id: Id of an existing question to seed
+                the pad from.
 
         Returns:
             The created pad.
@@ -156,6 +159,8 @@ class PadsNamespace(_Namespace):
             data["contents"] = contents
         if notes is not None:
             data["notes"] = notes
+        if question_id is not None:
+            data["question_id"] = str(question_id)
         response = self._request(
             method="POST",
             url="/api/pads/",

--- a/src/coderpad/client.py
+++ b/src/coderpad/client.py
@@ -160,7 +160,7 @@ class PadsNamespace(_Namespace):
         if notes is not None:
             data["notes"] = notes
         if question_id is not None:
-            data["question_id"] = str(question_id)
+            data["question_id"] = str(object=question_id)
         response = self._request(
             method="POST",
             url="/api/pads/",

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -4,6 +4,7 @@ from http import HTTPStatus
 from pathlib import Path
 
 import pytest
+import respx
 
 from coderpad.async_client import AsyncCoderPad
 from coderpad.exceptions import NotFoundError
@@ -214,6 +215,18 @@ class TestAsyncCreatePad:
             language=Language.PYTHON,
         )
         assert result.id
+
+    @staticmethod
+    @pytest.mark.asyncio
+    async def test_create_pad_from_question(
+        async_coderpad_client: AsyncCoderPad,
+        mock_coderpad_api: respx.MockRouter,
+    ) -> None:
+        """A pad can be spawned from an existing question id."""
+        result = await async_coderpad_client.pads.create(question_id=54321)
+        assert result.id
+        request = mock_coderpad_api.calls.last.request
+        assert b"question_id=54321" in request.content
 
 
 class TestAsyncGetPad:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,6 +4,7 @@ from http import HTTPStatus
 from pathlib import Path
 
 import pytest
+import respx
 
 from coderpad.client import CoderPad
 from coderpad.exceptions import (
@@ -423,6 +424,17 @@ class TestCreatePad:
             language=Language.PYTHON,
         )
         assert result.id
+
+    @staticmethod
+    def test_create_pad_from_question(
+        coderpad_client: CoderPad,
+        mock_coderpad_api: respx.MockRouter,
+    ) -> None:
+        """A pad can be spawned from an existing question id."""
+        result = coderpad_client.pads.create(question_id=54321)
+        assert result.id
+        request = mock_coderpad_api.calls.last.request
+        assert b"question_id=54321" in request.content
 
 
 class TestGetPad:


### PR DESCRIPTION
## Summary
- Add `question_id: str | int | None` kwarg to `PadsNamespace.create` (sync and async), forwarded as form data to `POST /api/pads/`.
- Enables `client.pads.create(question_id=...)` to spawn a pad seeded from an existing question without reaching into `_request`.

Closes #115.

## Test plan
- [x] New `test_create_pad_from_question` (sync + async) verifies the form field is sent.
- [x] Full test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an optional `question_id` form field to pad creation and covers it with new sync/async tests; no changes to auth, data models, or request flow beyond an extra parameter.
> 
> **Overview**
> Enables creating a pad seeded from an existing question by adding an optional `question_id` argument to `PadsNamespace.create` and `AsyncPadsNamespace.create`, forwarded as `question_id` form data to `POST /api/pads/`.
> 
> Adds sync and async tests (`test_create_pad_from_question`) that assert the outgoing request includes `question_id=...`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1710d76e61dcb0ae845874bd516d78bd2d337db4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->