### PR TITLE
ci: bump astral-sh/setup-uv from v7 to v8.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
           cache-dependency-glob: '**/pyproject.toml'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,7 @@ jobs:
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
           cache-dependency-glob: '**/pyproject.toml'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
           cache-dependency-glob: '**/pyproject.toml'


### PR DESCRIPTION
## Summary
- Bumps `astral-sh/setup-uv` from v7 to v8.1.0 across all GitHub Actions workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only updates the `astral-sh/setup-uv` GitHub Action version used in CI/lint/release workflows, with no runtime or application code changes. Main risk is CI/release behavior changing if `setup-uv` has breaking changes or different caching defaults.
> 
> **Overview**
> Updates GitHub Actions workflows to use `astral-sh/setup-uv@v8.1.0` (from `v7`) in **test**, **lint**, and **release** pipelines, keeping the existing uv cache settings intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fff6c65f53002b2f905ffe5094cfb71a61265e6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->