### PR TITLE
Enable mypy parallel workers in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -169,10 +169,10 @@ repos:
       - id: mypy-docs
         name: mypy-docs
         stages: [pre-push]
-        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy"
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy
+          --num-workers=4"
         language: python
         types_or: [markdown, rst]
-        args: [--num-workers=4]
         additional_dependencies:
           - *uv_version
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -157,11 +157,10 @@ repos:
       - id: mypy
         name: mypy
         stages: [pre-push]
-        entry: uv run --extra=dev -m mypy
+        entry: uv run --extra=dev -m mypy --num-workers=4
         language: python
         types_or: [python, toml]
         pass_filenames: false
-        args: [--num-workers=4]
         additional_dependencies:
           - *uv_version
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -161,6 +161,7 @@ repos:
         language: python
         types_or: [python, toml]
         pass_filenames: false
+        args: [--num-workers=4]
         additional_dependencies:
           - *uv_version
 
@@ -171,6 +172,7 @@ repos:
         entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy"
         language: python
         types_or: [markdown, rst]
+        args: [--num-workers=4]
         additional_dependencies:
           - *uv_version
 


### PR DESCRIPTION
## Summary
- Add `--num-workers=4` to pre-commit hook args for `mypy`.
- Add `--num-workers=4` to pre-commit hook args for `mypy-docs`.
- Keep all other pre-commit configuration unchanged.

## Test plan
- [x] Confirm only `.pre-commit-config.yaml` changed.
- [ ] Run `pre-commit run mypy --all-files`.
- [ ] Run `pre-commit run mypy-docs --all-files`.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change; it only adjusts pre-push mypy invocations and could at most affect developer workflow performance or reveal concurrency-related mypy issues.
> 
> **Overview**
> Speeds up type-checking in local workflows by running `mypy` with **4 parallel workers** in the `pre-push` pre-commit hook.
> 
> Updates the `mypy-docs` hook to pass the same `--num-workers=4` flag through `doccmd`, leaving the rest of `.pre-commit-config.yaml` unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1874f668a6cf2e9111d3528bf2e0fb7ad5108cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->