### PR TITLE
chore: Apply pyproject-fmt 2.23.0 formatting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,13 +95,13 @@ urls.Source = "https://github.com/adamtheturtle/coderpad-api-python"
 dev = []
 
 [tool.setuptools]
-zip-safe = false
-package-data.coderpad = [
-    "py.typed",
-]
 packages.find.where = [
     "src",
 ]
+package-data.coderpad = [
+    "py.typed",
+]
+zip-safe = false
 
 [tool.distutils]
 bdist_wheel.universal = true
@@ -154,11 +154,78 @@ lint.flake8-tidy-imports.banned-api."typing.cast".msg = "typing.cast is banned: 
 lint.pydocstyle.convention = "google"
 
 [tool.pylint]
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+"MESSAGES CONTROL".disable = [
+    # Too difficult to please
+    "duplicate-code",
+    # Let ruff handle long lines
+    "line-too-long",
+    "locally-disabled",
+    "missing-return-type-doc",
+    # We don't need everything to be documented because of mypy
+    "missing-type-doc",
+    "too-few-public-methods",
+    "too-many-arguments",
+    "too-many-instance-attributes",
+    "too-many-lines",
+    "too-many-locals",
+    "too-many-return-statements",
+    # Let ruff deal with sorting
+    "ungrouped-imports",
+    # Let ruff handle unused imports
+    "unused-import",
+    # mypy does not want untyped parameters.
+    "useless-type-doc",
+    # Let ruff handle imports
+    "wrong-import-order",
+]
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+"MESSAGES CONTROL".enable = [
+    "bad-inline-option",
+    "deprecated-pragma",
+    "file-ignored",
+    "spelling",
+    "use-symbolic-message-instead",
+    "useless-suppression",
+]
+# We ignore invalid names because:
+# - We want to use generated module names, which may not be valid, but are never seen.
+# - We want to use global variables in documentation, which may not be uppercase.
+# - conf.py is a Sphinx configuration file which requires lowercase global variable names.
+"MESSAGES CONTROL".per-file-ignores = [
+    "docs/source/conf.py:invalid-name",
+    "docs/source/doccmd_*.py:invalid-name",
+    "doccmd_README_rst_*.py:invalid-name",
+]
+DEPRECATED_BUILTINS.bad-functions = [
+    # Use Pylint until Ruff can ban bare builtin calls, or until custom rules
+    # make this removable:
+    # https://github.com/astral-sh/ruff/issues/10079
+    # https://github.com/astral-sh/ruff/issues/970
+    "filter",
+    "getattr",
+    "hasattr",
+    "map",
+    "setattr",
+]
 # Allow the body of an if to be on the same line as the test if there is no
 # else.
 FORMAT.single-line-if-stmt = false
-# Pickle collected data for later comparisons.
-MASTER.persistent = true
+# Return non-zero exit code if useless-suppression is emitted.
+MAIN.fail-on = [
+    "useless-suppression",
+]
 # Use multiple processes to speed up Pylint.
 MASTER.jobs = 0
 # List of plugins (as comma separated values of python modules names) to load,
@@ -171,7 +238,6 @@ MASTER.jobs = 0
 # - pylint.extensions.while_used
 # as they seemed to get in the way.
 MASTER.load-plugins = [
-    "pylint_per_file_ignores",
     "pylint.extensions.bad_builtin",
     "pylint.extensions.comparison_placement",
     "pylint.extensions.consider_refactoring_into_while_condition",
@@ -187,79 +253,13 @@ MASTER.load-plugins = [
     "pylint.extensions.redefined_variable_type",
     "pylint.extensions.set_membership",
     "pylint.extensions.typing",
+    "pylint_per_file_ignores",
 ]
+# Pickle collected data for later comparisons.
+MASTER.persistent = true
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.
 MASTER.unsafe-load-any-extension = false
-# Return non-zero exit code if useless-suppression is emitted.
-MAIN.fail-on = [
-    "useless-suppression",
-]
-DEPRECATED_BUILTINS.bad-functions = [
-    # Use Pylint until Ruff can ban bare builtin calls, or until custom rules
-    # make this removable:
-    # https://github.com/astral-sh/ruff/issues/10079
-    # https://github.com/astral-sh/ruff/issues/970
-    "filter",
-    "getattr",
-    "hasattr",
-    "map",
-    "setattr",
-]
-# Enable the message, report, category or checker with the given id(s). You can
-# either give multiple identifier separated by comma (,) or put this option
-# multiple time (only on the command line, not in the configuration file where
-# it should appear only once). See also the "--disable" option for examples.
-"MESSAGES CONTROL".enable = [
-    "bad-inline-option",
-    "deprecated-pragma",
-    "file-ignored",
-    "spelling",
-    "use-symbolic-message-instead",
-    "useless-suppression",
-]
-# Disable the message, report, category or checker with the given id(s). You
-# can either give multiple identifiers separated by comma (,) or put this
-# option multiple times (only on the command line, not in the configuration
-# file where it should appear only once).You can also use "--disable=all" to
-# disable everything first and then reenable specific checks. For example, if
-# you want to run only the similarities checker, you can use "--disable=all
-# --enable=similarities". If you want to run only the classes checker, but have
-# no Warning level messages displayed, use"--disable=all --enable=classes
-# --disable=W"
-"MESSAGES CONTROL".disable = [
-    "too-few-public-methods",
-    "too-many-locals",
-    "too-many-arguments",
-    "too-many-instance-attributes",
-    "too-many-return-statements",
-    "too-many-lines",
-    "locally-disabled",
-    # Let ruff handle long lines
-    "line-too-long",
-    # Let ruff handle unused imports
-    "unused-import",
-    # Let ruff deal with sorting
-    "ungrouped-imports",
-    # We don't need everything to be documented because of mypy
-    "missing-type-doc",
-    "missing-return-type-doc",
-    # Too difficult to please
-    "duplicate-code",
-    # Let ruff handle imports
-    "wrong-import-order",
-    # mypy does not want untyped parameters.
-    "useless-type-doc",
-]
-# We ignore invalid names because:
-# - We want to use generated module names, which may not be valid, but are never seen.
-# - We want to use global variables in documentation, which may not be uppercase.
-# - conf.py is a Sphinx configuration file which requires lowercase global variable names.
-"MESSAGES CONTROL".per-file-ignores = [
-    "docs/source/conf.py:invalid-name",
-    "docs/source/doccmd_*.py:invalid-name",
-    "doccmd_README_rst_*.py:invalid-name",
-]
 # Spelling dictionary name. Available dictionaries: none. To make it working
 # install python-enchant package.
 SPELLING.spelling-dict = "en_US"
@@ -269,30 +269,35 @@ SPELLING.spelling-private-dict-file = "spelling_private_dict.txt"
 # --spelling-private-dict-file option instead of raising a message.
 SPELLING.spelling-store-unknown-words = "no"
 
+[tool.interrogate]
+fail-under = 100
+verbose = 2
+omit-covered-files = true
+
 [tool.check-manifest]
 ignore = [
+    "*.enc",
     ".checkmake-config.ini",
+    ".git_archival.txt",
+    ".pre-commit-config.yaml",
     ".prettierrc",
     ".yamlfmt",
-    "*.enc",
-    ".pre-commit-config.yaml",
     "CHANGELOG.rst",
-    "newsfragments",
-    "newsfragments/**",
-    "CODE_OF_CONDUCT.rst",
-    "CONTRIBUTING.rst",
-    "LICENSE",
-    "Makefile",
     "ci",
     "ci/**",
+    "CODE_OF_CONDUCT.rst",
+    "CONTRIBUTING.rst",
     "doc8.ini",
     "docs",
     "docs/**",
-    ".git_archival.txt",
+    "LICENSE",
+    "lint.mk",
+    "Makefile",
+    "newsfragments",
+    "newsfragments/**",
     "spelling_private_dict.txt",
     "tests",
     "tests/**",
-    "lint.mk",
     "zizmor.yml",
 ]
 
@@ -302,16 +307,116 @@ optional_dependencies_dev_groups = [
     "release",
 ]
 
+[tool.vulture]
+exclude = [ ".venv" ]
+# Ideally we would limit the paths to the source code where we want to ignore names,
+# but Vulture does not enable this.
+ignore_names = [
+    # Async context manager dunder
+    "__aexit__",
+    # pytest fixtures - we name fixtures like this for this purpose
+    "_fixture_*",
+    # Language enum members (public API)
+    "ANGULAR",
+    # Sphinx
+    "autoclass_content",
+    "autodoc_member_order",
+    "BASH",
+    "C",
+    "CLOJURE",
+    "COFFEESCRIPT",
+    "copybutton_exclude",
+    "CPP",
+    "CSHARP",
+    "DART",
+    "DJANGO",
+    "ELIXIR",
+    "ERLANG",
+    "extensions",
+    "fixture_*",
+    "FSHARP",
+    "GIN",
+    "GO",
+    "GSHEETS",
+    "HACK",
+    "HASKELL",
+    "HTML",
+    "html_show_copyright",
+    "html_show_sourcelink",
+    "html_show_sphinx",
+    "html_theme",
+    "html_theme_options",
+    "html_title",
+    "htmlhelp_basename",
+    "intersphinx_mapping",
+    "JAVA",
+    "JAVASCRIPT",
+    "JULIA",
+    "KOTLIN",
+    "KUBERNETES",
+    "language",
+    "linkcheck_ignore",
+    "linkcheck_retries",
+    "LUA",
+    "MARKDOWN",
+    "master_doc",
+    "MULTIFILE_*",
+    "MYSQL",
+    "NEXTJS",
+    "nitpick_ignore",
+    "nitpick_ignore_regex",
+    "nitpicky",
+    "NODEJS",
+    "OBJC",
+    "OCAML",
+    "PERL",
+    "PHP",
+    "PLAINTEXT",
+    "POSTGRESQL",
+    "POWERSHELL",
+    "project_copyright",
+    "pygments_style",
+    # pytest configuration
+    "pytest_collect_file",
+    "pytest_plugins",
+    "PYTHON3",
+    "R",
+    "RAILS",
+    "REACT",
+    "REACT_NATIVE_WEB",
+    "rst_prolog",
+    "RUBY",
+    "RUST",
+    "SCALA",
+    "SOLIDITY",
+    "source_suffix",
+    "spelling_word_list_filename",
+    "SPRING",
+    "SVELTE",
+    "SWIFT",
+    "TCL",
+    "templates_path",
+    "towncrier_draft_autoversion_mode",
+    "towncrier_draft_include_empty",
+    "towncrier_draft_working_directory",
+    "TYPESCRIPT",
+    "UNIVERSAL",
+    "VB",
+    "VERILOG",
+    "VUE",
+    "warning_is_error",
+]
+
 [tool.pyproject-fmt]
 indent = 4
 keep_full_version = true
 max_supported_python = "3.14"
 
 [tool.mypy]
-strict = true
 files = [ "." ]
 exclude = [ "build" ]
 follow_untyped_imports = true
+strict = true
 plugins = [
     "mypy_strict_kwargs",
 ]
@@ -320,14 +425,14 @@ plugins = [
 errors.non-exhaustive-match = "error"
 
 [tool.pyright]
+typeCheckingMode = "strict"
 enableTypeIgnoreComments = false
 reportUnnecessaryTypeIgnoreComment = true
-typeCheckingMode = "strict"
 
 [tool.pytest]
-xfail_strict = true
-log_cli = true
 asyncio_mode = "strict"
+log_cli = true
+xfail_strict = true
 
 [tool.coverage]
 run.branch = true
@@ -348,11 +453,11 @@ filename = "CHANGELOG.rst"
 # date) followed by a flat bullet list with no per-type sub-headings.
 template = "docs/towncrier_template.rst.jinja"
 title_format = "{version}"
+issue_format = "#{issue}"
 # ``title_format`` underline first, then any nested headings.  A bare
 # version such as ``2026.05.18`` underlined with ``-`` matches every
 # pre-towncrier entry in CHANGELOG.rst.
 underlines = [ "-", "~", "^" ]
-issue_format = "#{issue}"
 type = [
     # A single, unnamed fragment type keeps the assembled output as one
     # flat bullet list, matching the historical changelog (which never
@@ -369,11 +474,6 @@ split-summary-body = false
 max-line-length = 75
 linewrap-full-docstring = true
 
-[tool.interrogate]
-fail-under = 100
-omit-covered-files = true
-verbose = 2
-
 [tool.doc8]
 max_line_length = 2000
 ignore_path = [
@@ -384,106 +484,6 @@ ignore_path = [
     "./src/*.egg-info/",
     "./src/*/_setuptools_scm_version.txt",
 ]
-
-[tool.vulture]
-# Ideally we would limit the paths to the source code where we want to ignore names,
-# but Vulture does not enable this.
-ignore_names = [
-    # Async context manager dunder
-    "__aexit__",
-    # pytest configuration
-    "pytest_collect_file",
-    "pytest_plugins",
-    # pytest fixtures - we name fixtures like this for this purpose
-    "_fixture_*",
-    "fixture_*",
-    # Language enum members (public API)
-    "ANGULAR",
-    "BASH",
-    "C",
-    "CLOJURE",
-    "COFFEESCRIPT",
-    "CPP",
-    "CSHARP",
-    "DART",
-    "DJANGO",
-    "ELIXIR",
-    "ERLANG",
-    "FSHARP",
-    "GIN",
-    "GO",
-    "GSHEETS",
-    "HACK",
-    "HASKELL",
-    "HTML",
-    "JAVA",
-    "JAVASCRIPT",
-    "JULIA",
-    "KOTLIN",
-    "KUBERNETES",
-    "LUA",
-    "MARKDOWN",
-    "MULTIFILE_*",
-    "MYSQL",
-    "NEXTJS",
-    "NODEJS",
-    "OBJC",
-    "OCAML",
-    "PERL",
-    "PHP",
-    "PLAINTEXT",
-    "POSTGRESQL",
-    "POWERSHELL",
-    "PYTHON3",
-    "R",
-    "RAILS",
-    "REACT",
-    "REACT_NATIVE_WEB",
-    "RUBY",
-    "RUST",
-    "SCALA",
-    "SOLIDITY",
-    "SPRING",
-    "SVELTE",
-    "SWIFT",
-    "TCL",
-    "TYPESCRIPT",
-    "UNIVERSAL",
-    "VB",
-    "VERILOG",
-    "VUE",
-    # Sphinx
-    "autoclass_content",
-    "autodoc_member_order",
-    "copybutton_exclude",
-    "extensions",
-    "html_show_copyright",
-    "html_show_sourcelink",
-    "html_show_sphinx",
-    "html_theme",
-    "html_theme_options",
-    "html_title",
-    "htmlhelp_basename",
-    "intersphinx_mapping",
-    "language",
-    "linkcheck_ignore",
-    "linkcheck_retries",
-    "master_doc",
-    "nitpicky",
-    "nitpick_ignore",
-    "nitpick_ignore_regex",
-    "project_copyright",
-    "pygments_style",
-    "rst_prolog",
-    "source_suffix",
-    "spelling_word_list_filename",
-    "templates_path",
-    "warning_is_error",
-    "towncrier_draft_autoversion_mode",
-    "towncrier_draft_include_empty",
-    "towncrier_draft_working_directory",
-]
-exclude = [ ".venv" ]
 
 [tool.yamlfix]
 section_whitelines = 1


### PR DESCRIPTION
## Summary

- `pyproject-fmt` was upgraded to 2.23.0 in a previous PR but the `pyproject.toml` was never reformatted with the new version
- This causes lint CI to fail on `main` and all open dependabot PRs (which run `pyproject-fmt 2.23.0` and detect the drift)
- Applied `pyproject-fmt 2.23.0` formatting — 196 lines changed, all pure reordering within sections (no content removed or added)

## Test plan

- [ ] Lint CI passes on this PR
- [ ] After merge, re-run CI on the open dependabot PRs to confirm they pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic TOML reordering with no runtime or dependency changes; only risk is an accidental edit, which the PR scope excludes.
> 
> **Overview**
> Reformats **`pyproject.toml`** with **pyproject-fmt 2.23.0** so the file matches what CI/pre-commit already enforce, fixing lint drift on `main` and Dependabot PRs after the formatter was bumped without re-running it.
> 
> The diff is **layout-only**: keys and table blocks are reordered (e.g. `[tool.setuptools]`, `[tool.pylint]`, `[tool.mypy]` / pyright / pytest, `[tool.interrogate]`, `[tool.vulture]`, `[tool.check-manifest]` ignore lists, towncrier fields). **No intentional config value changes**—same plugins, disables, and tool settings, just canonical ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1af38a7b5f4c861e54ff9cd535910b9dd429a2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->