### PR TITLE
chore(deps-dev): Bump strict-kwargs from 2026.5.20 to 2026.6.4

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -302,7 +302,7 @@ repos:
 
       - id: strict-kwargs-fix
         name: strict-kwargs
-        entry: uv run --extra=dev strict-kwargs fix --diff
+        entry: uv run --extra=dev strict-kwargs check --fix
         language: python
         types_or: [python]
         additional_dependencies:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ optional-dependencies.dev = [
     # ``sphinxcontrib-towncrier`` renders unreleased news fragments
     # into docs/source/unreleased.rst during Sphinx builds.
     "sphinxcontrib-towncrier==0.5.0a0",
-    "strict-kwargs==2026.5.20",
+    "strict-kwargs==2026.6.4",
     "sybil==10.0.1",
     "towncrier==25.8.0",
     "ty==0.0.44",


### PR DESCRIPTION
## Summary

- Bumps `strict-kwargs` from 2026.5.20 to 2026.6.4
- Updates the pre-commit hook command from `fix --diff` to `check --fix` to match the new CLI (the `fix` subcommand was replaced by `check --fix` in 2026.6.4)
- Closes/supersedes dependabot PR #163 which was failing due to the CLI change

## Test plan

- [ ] Lint CI passes on this PR (particularly the `strict-kwargs` hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only tooling and pre-commit hook wiring; no runtime or application code changes.
> 
> **Overview**
> Bumps the dev dependency **`strict-kwargs`** from `2026.5.20` to **`2026.6.4`**.
> 
> The **`strict-kwargs-fix`** pre-commit hook entry is updated from `strict-kwargs fix --diff` to **`strict-kwargs check --fix`** so local lint still auto-fixes kwargs after the CLI change in the new release (the old `fix` subcommand was removed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43e6b17ba7683317a14e187be49570212d738072. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->