### PR TITLE
Document writable vs read-only fields for questions and pads

### DIFF
--- a/docs/source/field-reference.rst
+++ b/docs/source/field-reference.rst
@@ -1,0 +1,201 @@
+Writable and read-only fields
+=============================
+
+The :class:`~coderpad.types.Question` and :class:`~coderpad.types.Pad`
+models expose more fields than the ``create`` and ``update`` methods
+accept.  A field that is present when you read a resource is not
+necessarily a field that you can write.
+
+This page documents which fields are writable so that the gap is
+explicit.  It is especially relevant when syncing resources from
+source control, where a read field that cannot be written is
+surprising.
+
+Questions
+---------
+
+Writable fields are accepted by
+:meth:`coderpad.client.QuestionsNamespace.create` and
+:meth:`coderpad.client.QuestionsNamespace.update`.  Every other field
+on :class:`~coderpad.types.Question` is populated by the server and
+returned on read only.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 20 50
+
+   * - Field
+     - Write support
+     - Notes
+   * - ``title``
+     - Create and update
+     - Required on create.
+   * - ``language``
+     - Create and update
+     - Required on create.
+   * - ``description``
+     - Create and update
+     -
+   * - ``contents``
+     - Create and update
+     - Cannot be combined with ``file_contents``.
+   * - ``solution``
+     - Create and update
+     -
+   * - ``file_contents``
+     - Create and update
+     - For multi-file questions.  Maps to the read-side pad
+       environment files rather than to a single field.
+   * - ``zip_file``
+     - Create and update
+     - Upload alternative to ``file_contents``.
+   * - ``candidate_instructions``
+     - Read only
+     - Write support tracked in `#196`_.
+   * - ``test_cases``
+     - Read only
+     -
+   * - ``test_cases_enabled``
+     - Read only
+     -
+   * - ``contents_for_test_cases``
+     - Read only
+     -
+   * - ``take_home``
+     - Read only
+     -
+   * - ``shared``
+     - Read only
+     -
+   * - ``is_draft``
+     - Read only
+     -
+   * - ``custom_files``
+     - Read only
+     -
+   * - ``id``
+     - Read only
+     - Server-assigned.
+   * - ``owner_email``
+     - Read only
+     - Server-assigned.
+   * - ``used``
+     - Read only
+     - Server-managed usage count.
+   * - ``pad_type``
+     - Read only
+     - Server-managed.
+   * - ``author_name``
+     - Read only
+     - Server-managed.
+   * - ``organization_name``
+     - Read only
+     - Server-managed.
+   * - ``public_take_home_setting_id``
+     - Read only
+     - Server-managed.
+   * - ``created_at``
+     - Read only
+     - Server-managed timestamp.
+   * - ``updated_at``
+     - Read only
+     - Server-managed timestamp.
+
+Pads
+----
+
+Writable fields are accepted by
+:meth:`coderpad.client.PadsNamespace.create` and
+:meth:`coderpad.client.PadsNamespace.update`.  Every other field on
+:class:`~coderpad.types.Pad` is populated by the server and returned
+on read only.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 20 50
+
+   * - Field
+     - Write support
+     - Notes
+   * - ``title``
+     - Create and update
+     -
+   * - ``language``
+     - Create and update
+     -
+   * - ``contents``
+     - Create and update
+     -
+   * - ``notes``
+     - Create and update
+     - Private notes for the interviewer.
+   * - ``question_id``
+     - Create only
+     - Seeds the pad from an existing question.  Not a field on
+       the read model; see ``question_ids`` instead.
+   * - ``ended``
+     - Update only
+     - Set to ``True`` to end the interview.  Reflected on read as
+       ``ended_at``.
+   * - ``deleted``
+     - Update only
+     - Set to ``True`` to delete the pad.
+   * - ``id``
+     - Read only
+     - Server-assigned.
+   * - ``state``
+     - Read only
+     - Server-managed.
+   * - ``owner_email``
+     - Read only
+     - Server-assigned.
+   * - ``private``
+     - Read only
+     - Server-managed.
+   * - ``execution_enabled``
+     - Read only
+     - Server-managed.
+   * - ``participants``
+     - Read only
+     - Server-managed.
+   * - ``events``
+     - Read only
+     - Server-managed.
+   * - ``ended_at``
+     - Read only
+     - Set by passing ``ended`` to ``update``.
+   * - ``url``
+     - Read only
+     - Server-assigned.
+   * - ``playback``
+     - Read only
+     - Server-assigned.
+   * - ``drawing``
+     - Read only
+     - Server-managed.
+   * - ``type``
+     - Read only
+     - Server-managed.
+   * - ``question_ids``
+     - Read only
+     - Seed questions via ``question_id`` on ``create``.
+   * - ``pad_environment_ids``
+     - Read only
+     - Server-managed.
+   * - ``active_environment_id``
+     - Read only
+     - Server-managed.
+   * - ``team``
+     - Read only
+     - Server-managed.
+   * - ``history``
+     - Read only
+     - Server-managed.
+   * - ``created_at``
+     - Read only
+     - Server-managed timestamp.
+   * - ``updated_at``
+     - Read only
+     - Server-managed timestamp.
+
+.. _#196: https://github.com/adamtheturtle/coderpad-api-python/issues/196

--- a/docs/source/field-reference.rst
+++ b/docs/source/field-reference.rst
@@ -51,7 +51,7 @@ returned on read only.
      - Upload alternative to ``file_contents``.
    * - ``candidate_instructions``
      - Read only
-     - Write support tracked in `#196`_.
+     - Write support tracked in issue #196.
    * - ``test_cases``
      - Read only
      -
@@ -197,5 +197,3 @@ on read only.
    * - ``updated_at``
      - Read only
      - Server-managed timestamp.
-
-.. _#196: https://github.com/adamtheturtle/coderpad-api-python/issues/196

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -38,6 +38,7 @@ Reference
    :maxdepth: 3
 
    api-reference
+   field-reference
    openapi-spec
    contributing
    release-process

--- a/newsfragments/198.change.rst
+++ b/newsfragments/198.change.rst
@@ -1,0 +1,1 @@
+Documented which ``Question`` and ``Pad`` fields are writable versus read-only in a new "Writable and read-only fields" reference page.

--- a/src/coderpad/types.py
+++ b/src/coderpad/types.py
@@ -168,7 +168,11 @@ class Team:
 @beartype
 @dataclass(frozen=True, kw_only=True)
 class Pad:
-    """A CoderPad interview pad."""
+    """A CoderPad interview pad.
+
+    Not every field here can be written via ``create`` or ``update``.
+    See the "Writable and read-only fields" reference for the matrix.
+    """
 
     id: str
     title: str
@@ -450,7 +454,11 @@ class CustomFile:
 @beartype
 @dataclass(frozen=True, kw_only=True)
 class Question:
-    """A CoderPad question."""
+    """A CoderPad question.
+
+    Not every field here can be written via ``create`` or ``update``.
+    See the "Writable and read-only fields" reference for the matrix.
+    """
 
     id: int
     title: str


### PR DESCRIPTION
Closes #198.

## Summary

Several fields on the `Question` and `Pad` read models cannot be written via `create`/`update`, and that asymmetry was undocumented — callers (e.g. a Git-to-CoderPad sync tool) hit it only by trial. This addresses ask #1 of the issue: **document the writable vs read-only field matrix**.

- Adds a new **"Writable and read-only fields"** reference page (`docs/source/field-reference.rst`) with a per-field matrix for both questions and pads, marking each field as create/update, create-only, update-only, or read-only.
- Links to it from the `Question` and `Pad` model docstrings so the gap is discoverable from the API reference.
- Notes that `candidate_instructions` write support is tracked separately in #196.

## Scope

Ask #2 ("consider adding write support") is intentionally **not** included: the issue states each field needs verification against a live API key before exposing it as writable, which can't be done here. This PR closes the documentation gap; adding write support remains a follow-up.

## Validation

- `sphinx-build -W` (warnings-as-errors) HTML build succeeds — all `:class:`/`:meth:` cross-references resolve.
- `sphinx-build -b spelling -W` passes.
- doc8, ruff, pydocstringformatter, and the full pre-commit hook suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and docstring-only changes; no runtime or API behavior is modified.
> 
> **Overview**
> Adds a **Writable and read-only fields** Sphinx reference (`field-reference.rst`) that maps each `Question` and `Pad` attribute to create/update, create-only, update-only, or read-only, including notes such as `question_id` on pad create vs `question_ids` on read and that `candidate_instructions` writes are tracked in #196.
> 
> The page is linked from the docs toctree and from expanded `Question` and `Pad` class docstrings in `types.py`. A newsfragment records the change for issue #198.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f22ffd6c756f185f06225a1327a9e44d6daa7b79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->