### PR TITLE
Support writing candidate_instructions on questions create/update

### DIFF
--- a/newsfragments/196.change.rst
+++ b/newsfragments/196.change.rst
@@ -1,0 +1,1 @@
+Add a ``candidate_instructions`` parameter to ``questions.create`` and ``questions.update`` so progressively-revealed candidate instruction blocks can be authored via the API.

--- a/src/coderpad/async_client.py
+++ b/src/coderpad/async_client.py
@@ -15,6 +15,7 @@ from coderpad.transports import (
     TransportResponse,
 )
 from coderpad.types import (
+    CandidateInstruction,
     Language,
     Organization,
     OrganizationStats,
@@ -329,6 +330,7 @@ class AsyncQuestionsNamespace(_AsyncNamespace):
         description: str | None = None,
         contents: str | None = None,
         solution: str | None = None,
+        candidate_instructions: (Sequence[CandidateInstruction] | None) = None,
         file_contents: (Sequence[QuestionFileContent] | None) = None,
         zip_file: Path | None = None,
     ) -> Question:
@@ -343,6 +345,8 @@ class AsyncQuestionsNamespace(_AsyncNamespace):
                 session. Cannot be combined with
                 ``file_contents``.
             solution: The solution to the question.
+            candidate_instructions: Progressively-revealed
+                instruction blocks shown to the candidate.
             file_contents: Files for a multi-file question.
                 Cannot be combined with ``contents`` or
                 ``zip_file``.
@@ -364,6 +368,16 @@ class AsyncQuestionsNamespace(_AsyncNamespace):
             data["question[contents]"] = contents
         if solution is not None:
             data["question[solution]"] = solution
+        if candidate_instructions is not None:
+            data["question[candidate_instructions]"] = json.dumps(
+                obj=[
+                    {
+                        "instructions": ci.instructions,
+                        "default_visible": ci.default_visible,
+                    }
+                    for ci in candidate_instructions
+                ],
+            )
         if file_contents is not None:
             data["question[file_contents]"] = json.dumps(
                 obj=[
@@ -423,6 +437,7 @@ class AsyncQuestionsNamespace(_AsyncNamespace):
         description: str | None = None,
         contents: str | None = None,
         solution: str | None = None,
+        candidate_instructions: (Sequence[CandidateInstruction] | None) = None,
         file_contents: (Sequence[QuestionFileContent] | None) = None,
         zip_file: Path | None = None,
     ) -> None:
@@ -436,6 +451,8 @@ class AsyncQuestionsNamespace(_AsyncNamespace):
             contents: New contents. Cannot be combined with
                 ``file_contents``.
             solution: New solution.
+            candidate_instructions: Progressively-revealed
+                instruction blocks shown to the candidate.
             file_contents: Files for a multi-file question.
                 Cannot be combined with ``contents`` or
                 ``zip_file``.
@@ -457,6 +474,16 @@ class AsyncQuestionsNamespace(_AsyncNamespace):
             data["question[contents]"] = contents
         if solution is not None:
             data["question[solution]"] = solution
+        if candidate_instructions is not None:
+            data["question[candidate_instructions]"] = json.dumps(
+                obj=[
+                    {
+                        "instructions": ci.instructions,
+                        "default_visible": ci.default_visible,
+                    }
+                    for ci in candidate_instructions
+                ],
+            )
         if file_contents is not None:
             data["question[file_contents]"] = json.dumps(
                 obj=[

--- a/src/coderpad/client.py
+++ b/src/coderpad/client.py
@@ -15,6 +15,7 @@ from coderpad.transports import (
     TransportResponse,
 )
 from coderpad.types import (
+    CandidateInstruction,
     Language,
     Organization,
     OrganizationStats,
@@ -327,6 +328,7 @@ class QuestionsNamespace(_Namespace):
         description: str | None = None,
         contents: str | None = None,
         solution: str | None = None,
+        candidate_instructions: (Sequence[CandidateInstruction] | None) = None,
         file_contents: (Sequence[QuestionFileContent] | None) = None,
         zip_file: Path | None = None,
     ) -> Question:
@@ -340,6 +342,8 @@ class QuestionsNamespace(_Namespace):
                 session. Cannot be combined with
                 ``file_contents``.
             solution: The solution to the question.
+            candidate_instructions: Progressively-revealed
+                instruction blocks shown to the candidate.
             file_contents: Files for a multi-file question.
                 Cannot be combined with ``contents`` or
                 ``zip_file``.
@@ -361,6 +365,16 @@ class QuestionsNamespace(_Namespace):
             data["question[contents]"] = contents
         if solution is not None:
             data["question[solution]"] = solution
+        if candidate_instructions is not None:
+            data["question[candidate_instructions]"] = json.dumps(
+                obj=[
+                    {
+                        "instructions": ci.instructions,
+                        "default_visible": ci.default_visible,
+                    }
+                    for ci in candidate_instructions
+                ],
+            )
         if file_contents is not None:
             data["question[file_contents]"] = json.dumps(
                 obj=[
@@ -420,6 +434,7 @@ class QuestionsNamespace(_Namespace):
         description: str | None = None,
         contents: str | None = None,
         solution: str | None = None,
+        candidate_instructions: (Sequence[CandidateInstruction] | None) = None,
         file_contents: (Sequence[QuestionFileContent] | None) = None,
         zip_file: Path | None = None,
     ) -> None:
@@ -433,6 +448,8 @@ class QuestionsNamespace(_Namespace):
             contents: New contents. Cannot be combined with
                 ``file_contents``.
             solution: New solution.
+            candidate_instructions: Progressively-revealed
+                instruction blocks shown to the candidate.
             file_contents: Files for a multi-file question.
                 Cannot be combined with ``contents`` or
                 ``zip_file``.
@@ -454,6 +471,16 @@ class QuestionsNamespace(_Namespace):
             data["question[contents]"] = contents
         if solution is not None:
             data["question[solution]"] = solution
+        if candidate_instructions is not None:
+            data["question[candidate_instructions]"] = json.dumps(
+                obj=[
+                    {
+                        "instructions": ci.instructions,
+                        "default_visible": ci.default_visible,
+                    }
+                    for ci in candidate_instructions
+                ],
+            )
         if file_contents is not None:
             data["question[file_contents]"] = json.dumps(
                 obj=[

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -1,7 +1,9 @@
 """Tests for the async CoderPad client."""
 
+import json
 from http import HTTPStatus
 from pathlib import Path
+from urllib.parse import parse_qs
 
 import pytest
 import respx
@@ -13,7 +15,12 @@ from coderpad.transports import (
     AsyncTransport,
     TransportResponse,
 )
-from coderpad.types import Language, QuestionFileContent, SortOrder
+from coderpad.types import (
+    CandidateInstruction,
+    Language,
+    QuestionFileContent,
+    SortOrder,
+)
 
 
 class TestAsyncCoderPad:
@@ -381,6 +388,13 @@ class TestAsyncCreateQuestion:
             description="A description",
             contents="def solve(): pass",
             solution="def solve(): return 42",
+            candidate_instructions=[
+                CandidateInstruction(
+                    instructions="Part 1",
+                    default_visible=True,
+                ),
+                CandidateInstruction(instructions="Part 2"),
+            ],
         )
         assert result.id
 
@@ -433,6 +447,33 @@ class TestAsyncCreateQuestion:
             zip_file=zip_path,
         )
         assert result.id
+
+    @staticmethod
+    @pytest.mark.asyncio
+    async def test_create_question_candidate_instructions_body(
+        async_coderpad_client: AsyncCoderPad,
+        mock_coderpad_api: respx.MockRouter,
+    ) -> None:
+        """Candidate instructions are serialized into the form body."""
+        await async_coderpad_client.questions.create(
+            title="Live Question",
+            language="python",
+            candidate_instructions=[
+                CandidateInstruction(
+                    instructions="Part 1",
+                    default_visible=True,
+                ),
+                CandidateInstruction(instructions="Part 2"),
+            ],
+        )
+        request = mock_coderpad_api.calls.last.request
+        sent = parse_qs(qs=request.content.decode())
+        assert json.loads(
+            s=sent["question[candidate_instructions]"][0],
+        ) == [
+            {"instructions": "Part 1", "default_visible": True},
+            {"instructions": "Part 2", "default_visible": False},
+        ]
 
 
 class TestAsyncGetQuestion:
@@ -488,6 +529,13 @@ class TestAsyncUpdateQuestion:
             description="New desc",
             contents="puts 'hi'",
             solution="puts 'answer'",
+            candidate_instructions=[
+                CandidateInstruction(
+                    instructions="Part 1",
+                    default_visible=True,
+                ),
+                CandidateInstruction(instructions="Part 2"),
+            ],
         )
 
     @staticmethod
@@ -519,6 +567,32 @@ class TestAsyncUpdateQuestion:
             question_id="123",
             zip_file=zip_path,
         )
+
+    @staticmethod
+    @pytest.mark.asyncio
+    async def test_update_question_candidate_instructions_body(
+        async_coderpad_client: AsyncCoderPad,
+        mock_coderpad_api: respx.MockRouter,
+    ) -> None:
+        """Candidate instructions are serialized into the form body."""
+        await async_coderpad_client.questions.update(
+            question_id="123",
+            candidate_instructions=[
+                CandidateInstruction(
+                    instructions="Part 1",
+                    default_visible=True,
+                ),
+                CandidateInstruction(instructions="Part 2"),
+            ],
+        )
+        request = mock_coderpad_api.calls.last.request
+        sent = parse_qs(qs=request.content.decode())
+        assert json.loads(
+            s=sent["question[candidate_instructions]"][0],
+        ) == [
+            {"instructions": "Part 1", "default_visible": True},
+            {"instructions": "Part 2", "default_visible": False},
+        ]
 
 
 class TestAsyncDeleteQuestion:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,7 +1,9 @@
 """Tests for the CoderPad client."""
 
+import json
 from http import HTTPStatus
 from pathlib import Path
+from urllib.parse import parse_qs
 
 import pytest
 import respx
@@ -22,7 +24,12 @@ from coderpad.transports import (
     Transport,
     TransportResponse,
 )
-from coderpad.types import Language, QuestionFileContent, SortOrder
+from coderpad.types import (
+    CandidateInstruction,
+    Language,
+    QuestionFileContent,
+    SortOrder,
+)
 
 
 class TestCoderPad:
@@ -578,6 +585,13 @@ class TestCreateQuestion:
             description="A description",
             contents="def solve(): pass",
             solution="def solve(): return 42",
+            candidate_instructions=[
+                CandidateInstruction(
+                    instructions="Part 1",
+                    default_visible=True,
+                ),
+                CandidateInstruction(instructions="Part 2"),
+            ],
         )
         assert result.id
 
@@ -627,6 +641,32 @@ class TestCreateQuestion:
             zip_file=zip_path,
         )
         assert result.id
+
+    @staticmethod
+    def test_create_question_candidate_instructions_body(
+        coderpad_client: CoderPad,
+        mock_coderpad_api: respx.MockRouter,
+    ) -> None:
+        """Candidate instructions are serialized into the form body."""
+        coderpad_client.questions.create(
+            title="Live Question",
+            language="python",
+            candidate_instructions=[
+                CandidateInstruction(
+                    instructions="Part 1",
+                    default_visible=True,
+                ),
+                CandidateInstruction(instructions="Part 2"),
+            ],
+        )
+        request = mock_coderpad_api.calls.last.request
+        sent = parse_qs(qs=request.content.decode())
+        assert json.loads(
+            s=sent["question[candidate_instructions]"][0],
+        ) == [
+            {"instructions": "Part 1", "default_visible": True},
+            {"instructions": "Part 2", "default_visible": False},
+        ]
 
 
 class TestGetQuestion:
@@ -678,6 +718,13 @@ class TestUpdateQuestion:
             description="New desc",
             contents="puts 'hi'",
             solution="puts 'answer'",
+            candidate_instructions=[
+                CandidateInstruction(
+                    instructions="Part 1",
+                    default_visible=True,
+                ),
+                CandidateInstruction(instructions="Part 2"),
+            ],
         )
 
     @staticmethod
@@ -707,6 +754,31 @@ class TestUpdateQuestion:
             question_id="123",
             zip_file=zip_path,
         )
+
+    @staticmethod
+    def test_update_question_candidate_instructions_body(
+        coderpad_client: CoderPad,
+        mock_coderpad_api: respx.MockRouter,
+    ) -> None:
+        """Candidate instructions are serialized into the form body."""
+        coderpad_client.questions.update(
+            question_id="123",
+            candidate_instructions=[
+                CandidateInstruction(
+                    instructions="Part 1",
+                    default_visible=True,
+                ),
+                CandidateInstruction(instructions="Part 2"),
+            ],
+        )
+        request = mock_coderpad_api.calls.last.request
+        sent = parse_qs(qs=request.content.decode())
+        assert json.loads(
+            s=sent["question[candidate_instructions]"][0],
+        ) == [
+            {"instructions": "Part 1", "default_visible": True},
+            {"instructions": "Part 2", "default_visible": False},
+        ]
 
 
 class TestDeleteQuestion:


### PR DESCRIPTION
## Summary

Closes #196.

`QuestionsNamespace.create` / `.update` (sync and async) now accept a
`candidate_instructions: Sequence[CandidateInstruction] | None` parameter,
so the progressively-revealed candidate instruction blocks that `Question`
already reads can now be written back via the API. This unblocks a
"questions-as-code" workflow where live/multi-part questions are authored
in Git and uploaded to CoderPad.

## Serialisation

The blocks are encoded into the form body as a single JSON-encoded
`question[candidate_instructions]` field:

```
question[candidate_instructions]=[{"instructions": "Part 1", "default_visible": true}, ...]
```

This mirrors the existing `file_contents` convention in this client rather
than the Rails-style nested-array form floated in the issue, keeping the
two structured write params consistent.

> [!IMPORTANT]
> **Unverified against the live API.** As the issue flagged, the public
> CoderPad docs only document `title`/`description`/`language`/`contents`
> for `POST /api/questions`, and I do not have a write-capable key to
> confirm the endpoint accepts `candidate_instructions` (or which exact
> shape it wants). The tests here exercise the client's serialisation
> against the OpenAPI-backed mock, not the real server. Before relying on
> this, please verify with a live key — if the API rejects it, we should
> fall back to documenting the limitation instead.

## Tests

- Added `candidate_instructions` to the `*_all_params` create/update tests
  (sync + async).
- Added dedicated tests asserting the exact JSON body shape for both
  create and update (sync + async).

Full suite, ruff, ty, mypy, and pylint (10/10) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a write path for question content that may not match the live CoderPad API (undocumented field); behavior is only validated against mocks, so wrong payloads could fail or misconfigure questions in production.
> 
> **Overview**
> Adds optional **`candidate_instructions`** on **`questions.create`** and **`questions.update`** in both sync and async clients, so progressively-revealed instruction blocks can be sent when authoring questions via the API.
> 
> When provided, blocks are JSON-encoded into the form field **`question[candidate_instructions]`** (each entry has **`instructions`** and **`default_visible`**), matching the existing **`file_contents`** write pattern. A newsfragment documents the API change.
> 
> Tests cover the new parameter in all-params create/update flows and assert the exact serialized body for create and update (sync and async).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f08fe97406db5120bb6cd1ade7a17fc788c44ba0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->