### PR TITLE
Add pad editor history support

### DIFF
--- a/newsfragments/history.change
+++ b/newsfragments/history.change
@@ -1,0 +1,1 @@
+Add synchronous and asynchronous support for retrieving and replaying per-file pad editor history.

--- a/src/coderpad/_dict_types.py
+++ b/src/coderpad/_dict_types.py
@@ -49,12 +49,25 @@ class PadEventDict(TypedDict):
     created_at: str
 
 
+# An editor operation stored in a pad's Firebase history. The functional
+# form prevents static analysis from treating its abbreviated wire keys as
+# unused Python attributes.
+PadHistoryEntryDict = TypedDict(  # noqa: UP013
+    "PadHistoryEntryDict",
+    {
+        "a": str,
+        "o": list[int | str],
+        "t": int,
+    },
+)
+
+
 class FileContentDict(TypedDict):
     """A file within a pad environment."""
 
     path: str
     contents: str
-    history: str
+    history: NotRequired[str]
 
 
 class PadEnvironmentDict(TypedDict):

--- a/src/coderpad/async_client.py
+++ b/src/coderpad/async_client.py
@@ -22,6 +22,7 @@ from coderpad.types import (
     Pad,
     PadEnvironment,
     PadEvent,
+    PadHistory,
     PaginatedList,
     Question,
     QuestionFileContent,
@@ -283,6 +284,35 @@ class AsyncPadsNamespace(_AsyncNamespace):
         return PadEnvironment.from_dict(
             data=response.json(),
         )
+
+    async def get_history(self, *, history_url: str) -> PadHistory:
+        """Retrieve editor history from a Firebase history URL.
+
+        The URL is available as ``FileContent.history``. The CoderPad
+        API key is deliberately not sent to the Firebase host.
+
+        Args:
+            history_url: The history URL returned for a file in a pad
+                environment.
+
+        Returns:
+            The chronologically ordered editor history. An empty
+            history is returned when Firebase responds with ``null``.
+        """
+        response = await self.transport(
+            method="GET",
+            url=history_url,
+            headers={"Accept": "application/json"},
+            params=None,
+            data=None,
+            files=None,
+        )
+        if response.status_code >= HTTPStatus.BAD_REQUEST:
+            raise CoderPadError.from_response(response=response)
+        data = response.json()
+        if data is None:
+            return PadHistory()
+        return PadHistory.from_dict(data=data)
 
 
 @beartype

--- a/src/coderpad/client.py
+++ b/src/coderpad/client.py
@@ -22,6 +22,7 @@ from coderpad.types import (
     Pad,
     PadEnvironment,
     PadEvent,
+    PadHistory,
     PaginatedList,
     Question,
     QuestionFileContent,
@@ -282,6 +283,35 @@ class PadsNamespace(_Namespace):
         return PadEnvironment.from_dict(
             data=response.json(),
         )
+
+    def get_history(self, *, history_url: str) -> PadHistory:
+        """Retrieve editor history from a Firebase history URL.
+
+        The URL is available as ``FileContent.history``. The CoderPad
+        API key is deliberately not sent to the Firebase host.
+
+        Args:
+            history_url: The history URL returned for a file in a pad
+                environment.
+
+        Returns:
+            The chronologically ordered editor history. An empty
+            history is returned when Firebase responds with ``null``.
+        """
+        response = self.transport(
+            method="GET",
+            url=history_url,
+            headers={"Accept": "application/json"},
+            params=None,
+            data=None,
+            files=None,
+        )
+        if response.status_code >= HTTPStatus.BAD_REQUEST:
+            raise CoderPadError.from_response(response=response)
+        data = response.json()
+        if data is None:
+            return PadHistory()
+        return PadHistory.from_dict(data=data)
 
 
 @beartype

--- a/src/coderpad/types.py
+++ b/src/coderpad/types.py
@@ -18,6 +18,7 @@ from coderpad._dict_types import (
     PadDict,
     PadEnvironmentDict,
     PadEventDict,
+    PadHistoryEntryDict,
     QuestionDict,
     QuotaDict,
     TeamDict,
@@ -270,12 +271,119 @@ class PadEvent:
 
 @beartype
 @dataclass(frozen=True, kw_only=True)
+class PadHistoryEntry:
+    """An editor operation from a pad's Firebase history.
+
+    Positive integer operations retain existing characters, negative
+    integers delete characters, and strings insert text.
+    """
+
+    id: str
+    author: str
+    operations: list[int | str]
+    timestamp: int
+
+    @classmethod
+    def from_dict(
+        cls,
+        *,
+        entry_id: str,
+        data: PadHistoryEntryDict,
+    ) -> Self:
+        """Create from a Firebase history entry.
+
+        Args:
+            entry_id: The Firebase key for the entry.
+            data: The dictionary to convert.
+
+        Returns:
+            A new instance.
+        """
+        return cls(
+            id=entry_id,
+            author=data["a"],
+            operations=data["o"],
+            timestamp=data["t"],
+        )
+
+    def apply(self, *, contents: str) -> str:
+        """Apply this operation to existing file contents.
+
+        Args:
+            contents: The contents immediately before this operation.
+
+        Returns:
+            The updated contents.
+        """
+        cursor = 0
+        updated: list[str] = []
+        for operation in self.operations:
+            if isinstance(operation, str):
+                updated.append(operation)
+            elif operation > 0:
+                updated.append(contents[cursor : cursor + operation])
+                cursor += operation
+            else:
+                cursor -= operation
+        updated.append(contents[cursor:])
+        return "".join(updated)
+
+
+@beartype
+class PadHistory(list[PadHistoryEntry]):
+    """Chronologically ordered editor history for a pad file."""
+
+    @classmethod
+    def from_dict(
+        cls,
+        *,
+        data: dict[str, PadHistoryEntryDict],
+    ) -> Self:
+        """Create from a Firebase history response.
+
+        Args:
+            data: Firebase keys mapped to editor operations.
+
+        Returns:
+            A chronologically ordered history.
+        """
+        ordered_entries = sorted(
+            data.items(),
+            key=lambda item: (item[1]["t"], item[0]),
+        )
+        history = cls()
+        for entry_id, entry in ordered_entries:
+            history.append(
+                PadHistoryEntry.from_dict(
+                    entry_id=entry_id,
+                    data=entry,
+                ),
+            )
+        return history
+
+    def replay(self, *, initial_contents: str = "") -> str:
+        """Replay all operations and return the resulting contents.
+
+        Args:
+            initial_contents: Contents before the first operation.
+
+        Returns:
+            The contents after all operations.
+        """
+        contents = initial_contents
+        for entry in self:
+            contents = entry.apply(contents=contents)
+        return contents
+
+
+@beartype
+@dataclass(frozen=True, kw_only=True)
 class FileContent:
     """A file within a pad environment."""
 
     path: str
     contents: str
-    history: str
+    history: str | None
 
     @classmethod
     def from_dict(
@@ -293,7 +401,7 @@ class FileContent:
         return cls(
             path=data["path"],
             contents=data["contents"],
-            history=data["history"],
+            history=data.get("history"),
         )
 
 

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -336,6 +336,113 @@ class TestAsyncGetPadEnvironment:
         assert result.id
 
 
+class TestAsyncGetPadHistory:
+    """Tests for ``AsyncCoderPad.pads.get_history``."""
+
+    @staticmethod
+    @pytest.mark.asyncio
+    async def test_get_history() -> None:
+        """Editor history can be retrieved and replayed."""
+        history_url = "https://coderpad-1.firebaseio.com/history.json"
+
+        async def _history_transport(
+            *,
+            method: str,
+            url: str,
+            headers: dict[str, str],
+            params: (dict[str, str | int] | None) = None,
+            data: dict[str, str] | None = None,
+            files: (dict[str, tuple[str, bytes, str]] | None) = None,
+        ) -> TransportResponse:
+            """Return sample Firebase history."""
+            del params, data, files
+            assert method == "GET"
+            assert url == history_url
+            assert headers == {"Accept": "application/json"}
+            return TransportResponse(
+                status_code=HTTPStatus.OK,
+                headers={},
+                content=json.dumps(
+                    obj={
+                        "entry-1": {
+                            "a": "author-1",
+                            "o": ["hi"],
+                            "t": 1,
+                        },
+                    },
+                ).encode(),
+            )
+
+        client = AsyncCoderPad(
+            api_key="test-key",
+            transport=_history_transport,
+        )
+        history = await client.pads.get_history(history_url=history_url)
+        assert history.replay() == "hi"
+
+    @staticmethod
+    @pytest.mark.asyncio
+    async def test_get_empty_history() -> None:
+        """A Firebase null response becomes an empty history."""
+
+        async def _empty_history_transport(
+            *,
+            method: str,
+            url: str,
+            headers: dict[str, str],
+            params: (dict[str, str | int] | None) = None,
+            data: dict[str, str] | None = None,
+            files: (dict[str, tuple[str, bytes, str]] | None) = None,
+        ) -> TransportResponse:
+            """Return an empty Firebase history."""
+            del method, url, headers, params, data, files
+            return TransportResponse(
+                status_code=HTTPStatus.OK,
+                headers={},
+                content=b"null",
+            )
+
+        client = AsyncCoderPad(
+            api_key="test-key",
+            transport=_empty_history_transport,
+        )
+        history = await client.pads.get_history(
+            history_url="https://example.com/history.json",
+        )
+        assert not history
+
+    @staticmethod
+    @pytest.mark.asyncio
+    async def test_get_history_error() -> None:
+        """Firebase HTTP errors use the client exception hierarchy."""
+
+        async def _error_transport(
+            *,
+            method: str,
+            url: str,
+            headers: dict[str, str],
+            params: (dict[str, str | int] | None) = None,
+            data: dict[str, str] | None = None,
+            files: (dict[str, tuple[str, bytes, str]] | None) = None,
+        ) -> TransportResponse:
+            """Return a missing history response."""
+            del method, url, headers, params, data, files
+            return TransportResponse(
+                status_code=HTTPStatus.NOT_FOUND,
+                headers={},
+                content=b"Not Found",
+            )
+
+        client = AsyncCoderPad(
+            api_key="test-key",
+            transport=_error_transport,
+        )
+        with pytest.raises(expected_exception=NotFoundError):
+            await client.pads.get_history(
+                history_url="https://example.com/history.json",
+            )
+
+
 class TestAsyncListQuestions:
     """Tests for ``AsyncCoderPad.questions.list``."""
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -537,6 +537,110 @@ class TestGetPadEnvironment:
         assert result.id
 
 
+class TestGetPadHistory:
+    """Tests for ``CoderPad.pads.get_history``."""
+
+    @staticmethod
+    def test_get_history() -> None:
+        """Editor history can be retrieved and replayed."""
+        history_url = "https://coderpad-1.firebaseio.com/history.json"
+
+        def _history_transport(
+            *,
+            method: str,
+            url: str,
+            headers: dict[str, str],
+            params: dict[str, str | int] | None = None,
+            data: dict[str, str] | None = None,
+            files: (dict[str, tuple[str, bytes, str]] | None) = None,
+        ) -> TransportResponse:
+            """Return sample Firebase history."""
+            del params, data, files
+            assert method == "GET"
+            assert url == history_url
+            assert headers == {"Accept": "application/json"}
+            return TransportResponse(
+                status_code=HTTPStatus.OK,
+                headers={},
+                content=json.dumps(
+                    obj={
+                        "entry-1": {
+                            "a": "author-1",
+                            "o": ["hi"],
+                            "t": 1,
+                        },
+                    },
+                ).encode(),
+            )
+
+        client = CoderPad(
+            api_key="test-key",
+            transport=_history_transport,
+        )
+        history = client.pads.get_history(history_url=history_url)
+        assert history.replay() == "hi"
+
+    @staticmethod
+    def test_get_empty_history() -> None:
+        """A Firebase null response becomes an empty history."""
+
+        def _empty_history_transport(
+            *,
+            method: str,
+            url: str,
+            headers: dict[str, str],
+            params: dict[str, str | int] | None = None,
+            data: dict[str, str] | None = None,
+            files: (dict[str, tuple[str, bytes, str]] | None) = None,
+        ) -> TransportResponse:
+            """Return an empty Firebase history."""
+            del method, url, headers, params, data, files
+            return TransportResponse(
+                status_code=HTTPStatus.OK,
+                headers={},
+                content=b"null",
+            )
+
+        client = CoderPad(
+            api_key="test-key",
+            transport=_empty_history_transport,
+        )
+        history = client.pads.get_history(
+            history_url="https://example.com/history.json",
+        )
+        assert not history
+
+    @staticmethod
+    def test_get_history_error() -> None:
+        """Firebase HTTP errors use the client exception hierarchy."""
+
+        def _error_transport(
+            *,
+            method: str,
+            url: str,
+            headers: dict[str, str],
+            params: dict[str, str | int] | None = None,
+            data: dict[str, str] | None = None,
+            files: (dict[str, tuple[str, bytes, str]] | None) = None,
+        ) -> TransportResponse:
+            """Return a missing history response."""
+            del method, url, headers, params, data, files
+            return TransportResponse(
+                status_code=HTTPStatus.NOT_FOUND,
+                headers={},
+                content=b"Not Found",
+            )
+
+        client = CoderPad(
+            api_key="test-key",
+            transport=_error_transport,
+        )
+        with pytest.raises(expected_exception=NotFoundError):
+            client.pads.get_history(
+                history_url="https://example.com/history.json",
+            )
+
+
 class TestListQuestions:
     """Tests for ``CoderPad.questions.list``."""
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -11,6 +11,7 @@ from coderpad._dict_types import (
     PadDict,
     PadEnvironmentDict,
     PadEventDict,
+    PadHistoryEntryDict,
     QuestionDict,
     QuotaDict,
     TeamDict,
@@ -27,6 +28,8 @@ from coderpad.types import (
     Pad,
     PadEnvironment,
     PadEvent,
+    PadHistory,
+    PadHistoryEntry,
     Question,
     Quota,
     Team,
@@ -54,6 +57,15 @@ def _pad_event_dict() -> PadEventDict:
 def _file_content_dict() -> FileContentDict:
     """Sample FileContentDict."""
     return {"path": "main.py", "contents": "print(1)", "history": "v1"}
+
+
+def _pad_history_entry_dict() -> PadHistoryEntryDict:
+    """Sample PadHistoryEntryDict."""
+    return {
+        "a": "author-1",
+        "o": [1, "X", -2],
+        "t": 1_700_000_000_000,
+    }
 
 
 def _pad_environment_dict() -> PadEnvironmentDict:
@@ -228,6 +240,66 @@ class TestFileContent:
         assert result.path == data["path"]
         assert result.contents == data["contents"]
         assert result.history == "v1"
+
+    @staticmethod
+    def test_from_dict_without_history() -> None:
+        """A FileContent can omit its optional history URL."""
+        data: FileContentDict = {
+            "path": "main.py",
+            "contents": "print(1)",
+        }
+        result = FileContent.from_dict(data=data)
+        assert result.history is None
+
+
+class TestPadHistoryEntry:
+    """Tests for ``PadHistoryEntry``."""
+
+    @staticmethod
+    def test_from_dict() -> None:
+        """A history entry can be created from a dictionary."""
+        data = _pad_history_entry_dict()
+        result = PadHistoryEntry.from_dict(
+            entry_id="entry-1",
+            data=data,
+        )
+        assert result.id == "entry-1"
+        assert result.author == data["a"]
+        assert result.operations == data["o"]
+        assert result.timestamp == data["t"]
+
+    @staticmethod
+    def test_apply() -> None:
+        """Text operations can be applied to existing contents."""
+        entry = PadHistoryEntry.from_dict(
+            entry_id="entry-1",
+            data=_pad_history_entry_dict(),
+        )
+        assert entry.apply(contents="abcd") == "aXd"
+
+
+class TestPadHistory:
+    """Tests for ``PadHistory``."""
+
+    @staticmethod
+    def test_from_dict_orders_and_replays_entries() -> None:
+        """History entries are ordered and can be replayed."""
+        history = PadHistory.from_dict(
+            data={
+                "later": {
+                    "a": "author-1",
+                    "o": [2, "!"],
+                    "t": 2,
+                },
+                "earlier": {
+                    "a": "author-1",
+                    "o": [1, "i"],
+                    "t": 1,
+                },
+            },
+        )
+        assert [entry.id for entry in history] == ["earlier", "later"]
+        assert history.replay(initial_contents="h") == "hi!"
 
 
 class TestPadEnvironment:


### PR DESCRIPTION
Adds synchronous and asynchronous readers for per-file Firebase editor histories without forwarding CoderPad authentication.

Introduces typed, chronologically ordered history entries with operational-transform replay, and treats file history URLs as optional.

Adds comprehensive success, empty-history, error, ordering, and replay tests plus a changelog fragment; the suite maintains 100% coverage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API and types with isolated Firebase GETs; only a minor typing change on optional `FileContent.history`.
> 
> **Overview**
> Adds **sync and async** `pads.get_history(history_url=...)` to load per-file editor history from Firebase URLs on `FileContent`, using the transport **without** the CoderPad API auth header.
> 
> Introduces **`PadHistory` / `PadHistoryEntry`** with Firebase wire typing, timestamp ordering, and OT-style **`apply` / `replay`**. **`FileContent.history`** is now optional (`str | None`) when the API omits the URL.
> 
> Includes client and type tests (success, `null` → empty history, HTTP errors) plus a changelog fragment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 580906fac2664a548d2fce6843f6bb6a4e521654. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->