### PR TITLE
Add question AI Assist system prompt

### DIFF
--- a/newsfragments/219.change
+++ b/newsfragments/219.change
@@ -1,0 +1,2 @@
+Add an ``ai_assist_custom_system_prompt`` parameter to ``questions.create``
+to configure AI Assist's system prompt for a question.

--- a/src/coderpad/async_client.py
+++ b/src/coderpad/async_client.py
@@ -360,6 +360,7 @@ class AsyncQuestionsNamespace(_AsyncNamespace):
         description: str | None = None,
         contents: str | None = None,
         solution: str | None = None,
+        ai_assist_custom_system_prompt: str | None = None,
         candidate_instructions: (Sequence[CandidateInstruction] | None) = None,
         file_contents: (Sequence[QuestionFileContent] | None) = None,
         zip_file: Path | None = None,
@@ -375,6 +376,7 @@ class AsyncQuestionsNamespace(_AsyncNamespace):
                 session. Cannot be combined with
                 ``file_contents``.
             solution: The solution to the question.
+            ai_assist_custom_system_prompt: Custom system prompt for AI Assist.
             candidate_instructions: Progressively-revealed
                 instruction blocks shown to the candidate.
             file_contents: Files for a multi-file question.
@@ -398,6 +400,10 @@ class AsyncQuestionsNamespace(_AsyncNamespace):
             data["question[contents]"] = contents
         if solution is not None:
             data["question[solution]"] = solution
+        if ai_assist_custom_system_prompt is not None:
+            data["question[ai_assist_custom_system_prompt]"] = (
+                ai_assist_custom_system_prompt
+            )
         if candidate_instructions is not None:
             data["question[candidate_instructions]"] = json.dumps(
                 obj=[

--- a/src/coderpad/client.py
+++ b/src/coderpad/client.py
@@ -358,6 +358,7 @@ class QuestionsNamespace(_Namespace):
         description: str | None = None,
         contents: str | None = None,
         solution: str | None = None,
+        ai_assist_custom_system_prompt: str | None = None,
         candidate_instructions: (Sequence[CandidateInstruction] | None) = None,
         file_contents: (Sequence[QuestionFileContent] | None) = None,
         zip_file: Path | None = None,
@@ -372,6 +373,7 @@ class QuestionsNamespace(_Namespace):
                 session. Cannot be combined with
                 ``file_contents``.
             solution: The solution to the question.
+            ai_assist_custom_system_prompt: Custom system prompt for AI Assist.
             candidate_instructions: Progressively-revealed
                 instruction blocks shown to the candidate.
             file_contents: Files for a multi-file question.
@@ -395,6 +397,10 @@ class QuestionsNamespace(_Namespace):
             data["question[contents]"] = contents
         if solution is not None:
             data["question[solution]"] = solution
+        if ai_assist_custom_system_prompt is not None:
+            data["question[ai_assist_custom_system_prompt]"] = (
+                ai_assist_custom_system_prompt
+            )
         if candidate_instructions is not None:
             data["question[candidate_instructions]"] = json.dumps(
                 obj=[

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -530,6 +530,7 @@ class TestAsyncCreateQuestion:
             description="A description",
             contents="def solve(): pass",
             solution="def solve(): return 42",
+            ai_assist_custom_system_prompt="Only provide hints.",
             candidate_instructions=[
                 CandidateInstruction(
                     instructions="Part 1",
@@ -600,6 +601,7 @@ class TestAsyncCreateQuestion:
         await async_coderpad_client.questions.create(
             title="Live Question",
             language="python",
+            ai_assist_custom_system_prompt="Only provide hints.",
             candidate_instructions=[
                 CandidateInstruction(
                     instructions="Part 1",
@@ -610,6 +612,9 @@ class TestAsyncCreateQuestion:
         )
         request = mock_coderpad_api.calls.last.request
         sent = parse_qs(qs=request.content.decode())
+        assert sent["question[ai_assist_custom_system_prompt]"] == [
+            "Only provide hints.",
+        ]
         assert json.loads(
             s=sent["question[candidate_instructions]"][0],
         ) == [

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -723,6 +723,7 @@ class TestCreateQuestion:
             description="A description",
             contents="def solve(): pass",
             solution="def solve(): return 42",
+            ai_assist_custom_system_prompt="Only provide hints.",
             candidate_instructions=[
                 CandidateInstruction(
                     instructions="Part 1",
@@ -789,6 +790,7 @@ class TestCreateQuestion:
         coderpad_client.questions.create(
             title="Live Question",
             language="python",
+            ai_assist_custom_system_prompt="Only provide hints.",
             candidate_instructions=[
                 CandidateInstruction(
                     instructions="Part 1",
@@ -799,6 +801,9 @@ class TestCreateQuestion:
         )
         request = mock_coderpad_api.calls.last.request
         sent = parse_qs(qs=request.content.decode())
+        assert sent["question[ai_assist_custom_system_prompt]"] == [
+            "Only provide hints.",
+        ]
         assert json.loads(
             s=sent["question[candidate_instructions]"][0],
         ) == [


### PR DESCRIPTION
Adds an optional ai_assist_custom_system_prompt argument to sync and async question creation. The value is sent as the question[ai_assist_custom_system_prompt] form field, with request-body tests for both clients. Adds a release-note fragment. Validated with uv run --extra=dev pytest (147 passed).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, backward-compatible API extension on question create only; no auth or update-path changes.
> 
> **Overview**
> Adds optional **`ai_assist_custom_system_prompt`** to **`questions.create`** on both the sync and async clients so callers can set a per-question AI Assist system prompt when creating a question.
> 
> When the argument is provided, the client includes **`question[ai_assist_custom_system_prompt]`** in the create-question form body (same pattern as other optional question fields). **`questions.update`** is unchanged.
> 
> Tests assert the field is sent in the request body for sync and async create; a **newsfragments** entry documents the new parameter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03621445f0d65a97453c5b15b46848c950c440e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->