### PR TITLE
Add AI Assist system prompt support to question updates

### DIFF
--- a/newsfragments/233.change
+++ b/newsfragments/233.change
@@ -1,0 +1,2 @@
+Add ``ai_assist_custom_system_prompt`` to ``questions.update`` so AI Assist
+system prompts can be synchronized for existing questions.

--- a/src/coderpad/async_client.py
+++ b/src/coderpad/async_client.py
@@ -473,6 +473,7 @@ class AsyncQuestionsNamespace(_AsyncNamespace):
         description: str | None = None,
         contents: str | None = None,
         solution: str | None = None,
+        ai_assist_custom_system_prompt: str | None = None,
         candidate_instructions: (Sequence[CandidateInstruction] | None) = None,
         file_contents: (Sequence[QuestionFileContent] | None) = None,
         zip_file: Path | None = None,
@@ -487,6 +488,7 @@ class AsyncQuestionsNamespace(_AsyncNamespace):
             contents: New contents. Cannot be combined with
                 ``file_contents``.
             solution: New solution.
+            ai_assist_custom_system_prompt: Custom system prompt for AI Assist.
             candidate_instructions: Progressively-revealed
                 instruction blocks shown to the candidate.
             file_contents: Files for a multi-file question.
@@ -510,6 +512,10 @@ class AsyncQuestionsNamespace(_AsyncNamespace):
             data["question[contents]"] = contents
         if solution is not None:
             data["question[solution]"] = solution
+        if ai_assist_custom_system_prompt is not None:
+            data["question[ai_assist_custom_system_prompt]"] = (
+                ai_assist_custom_system_prompt
+            )
         if candidate_instructions is not None:
             data["question[candidate_instructions]"] = json.dumps(
                 obj=[

--- a/src/coderpad/client.py
+++ b/src/coderpad/client.py
@@ -470,6 +470,7 @@ class QuestionsNamespace(_Namespace):
         description: str | None = None,
         contents: str | None = None,
         solution: str | None = None,
+        ai_assist_custom_system_prompt: str | None = None,
         candidate_instructions: (Sequence[CandidateInstruction] | None) = None,
         file_contents: (Sequence[QuestionFileContent] | None) = None,
         zip_file: Path | None = None,
@@ -484,6 +485,7 @@ class QuestionsNamespace(_Namespace):
             contents: New contents. Cannot be combined with
                 ``file_contents``.
             solution: New solution.
+            ai_assist_custom_system_prompt: Custom system prompt for AI Assist.
             candidate_instructions: Progressively-revealed
                 instruction blocks shown to the candidate.
             file_contents: Files for a multi-file question.
@@ -507,6 +509,10 @@ class QuestionsNamespace(_Namespace):
             data["question[contents]"] = contents
         if solution is not None:
             data["question[solution]"] = solution
+        if ai_assist_custom_system_prompt is not None:
+            data["question[ai_assist_custom_system_prompt]"] = (
+                ai_assist_custom_system_prompt
+            )
         if candidate_instructions is not None:
             data["question[candidate_instructions]"] = json.dumps(
                 obj=[

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -676,6 +676,7 @@ class TestAsyncUpdateQuestion:
             description="New desc",
             contents="puts 'hi'",
             solution="puts 'answer'",
+            ai_assist_custom_system_prompt="Only provide hints.",
             candidate_instructions=[
                 CandidateInstruction(
                     instructions="Part 1",
@@ -739,6 +740,23 @@ class TestAsyncUpdateQuestion:
         ) == [
             {"instructions": "Part 1", "default_visible": True},
             {"instructions": "Part 2", "default_visible": False},
+        ]
+
+    @staticmethod
+    @pytest.mark.asyncio
+    async def test_update_question_ai_assist_system_prompt_body(
+        async_coderpad_client: AsyncCoderPad,
+        mock_coderpad_api: respx.MockRouter,
+    ) -> None:
+        """AI Assist's system prompt is serialized into the form body."""
+        await async_coderpad_client.questions.update(
+            question_id="123",
+            ai_assist_custom_system_prompt="Only provide hints.",
+        )
+        request = mock_coderpad_api.calls.last.request
+        sent = parse_qs(qs=request.content.decode())
+        assert sent["question[ai_assist_custom_system_prompt]"] == [
+            "Only provide hints.",
         ]
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -861,6 +861,7 @@ class TestUpdateQuestion:
             description="New desc",
             contents="puts 'hi'",
             solution="puts 'answer'",
+            ai_assist_custom_system_prompt="Only provide hints.",
             candidate_instructions=[
                 CandidateInstruction(
                     instructions="Part 1",
@@ -921,6 +922,22 @@ class TestUpdateQuestion:
         ) == [
             {"instructions": "Part 1", "default_visible": True},
             {"instructions": "Part 2", "default_visible": False},
+        ]
+
+    @staticmethod
+    def test_update_question_ai_assist_system_prompt_body(
+        coderpad_client: CoderPad,
+        mock_coderpad_api: respx.MockRouter,
+    ) -> None:
+        """AI Assist's system prompt is serialized into the form body."""
+        coderpad_client.questions.update(
+            question_id="123",
+            ai_assist_custom_system_prompt="Only provide hints.",
+        )
+        request = mock_coderpad_api.calls.last.request
+        sent = parse_qs(qs=request.content.decode())
+        assert sent["question[ai_assist_custom_system_prompt]"] == [
+            "Only provide hints.",
         ]
 
 


### PR DESCRIPTION
Adds `ai_assist_custom_system_prompt` support to synchronous and asynchronous question updates, with request-body coverage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, optional-parameter extension parallel to existing create support; no auth or core transport changes.
> 
> **Overview**
> **`questions.update`** on both sync and async clients now accepts optional **`ai_assist_custom_system_prompt`**, matching **`create`**: when set, it is sent as **`question[ai_assist_custom_system_prompt]`** on the PUT form body so existing questions can get AI Assist prompts updated in sync with create flows.
> 
> Tests cover the new field in “all params” updates and assert form serialization; a **newsfragment** documents the public API change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72b69921031b7ffccd6e06bac11a2bed237186ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->