### PR TITLE
Expose AI Assist system prompt on question responses

### DIFF
--- a/newsfragments/237.change
+++ b/newsfragments/237.change
@@ -1,0 +1,2 @@
+Expose the optional ``ai_assist_custom_system_prompt`` field on question
+responses so custom AI Assist prompts can be read and synchronized.

--- a/openapi.json
+++ b/openapi.json
@@ -2007,6 +2007,9 @@
                     "custom_files": {
                       "type": "array"
                     },
+                    "ai_assist_custom_system_prompt": {
+                      "type": "string"
+                    },
                     "created_at": {
                       "type": "string",
                       "format": "date-time"
@@ -2041,6 +2044,7 @@
                   "author_name": "ken",
                   "organization_name": "CoderPad",
                   "custom_files": [],
+                  "ai_assist_custom_system_prompt": "Only provide hints.",
                   "created_at": "2023-03-13T13:30:18Z",
                   "updated_at": "2023-03-13T13:32:06Z"
                 }
@@ -2724,6 +2728,9 @@
                               }
                             }
                           },
+                          "ai_assist_custom_system_prompt": {
+                            "type": "string"
+                          },
                           "created_at": {
                             "type": "string",
                             "format": "date-time"
@@ -2806,6 +2813,7 @@
                           ]
                         }
                       ],
+                      "ai_assist_custom_system_prompt": "Only provide hints.",
                       "created_at": "2020-08-17T07:27:53Z",
                       "updated_at": "2023-03-09T17:42:58Z"
                     },
@@ -3070,6 +3078,9 @@
                     "custom_files": {
                       "type": "array"
                     },
+                    "ai_assist_custom_system_prompt": {
+                      "type": "string"
+                    },
                     "created_at": {
                       "type": "string",
                       "format": "date-time"
@@ -3099,6 +3110,7 @@
                   "author_name": "ken",
                   "organization_name": "CoderPad",
                   "custom_files": [],
+                  "ai_assist_custom_system_prompt": "Only provide hints.",
                   "created_at": "2023-08-03T11:32:56Z",
                   "updated_at": "2023-08-03T11:32:56Z"
                 }
@@ -4440,6 +4452,9 @@
                           "custom_files": {
                             "type": "array"
                           },
+                          "ai_assist_custom_system_prompt": {
+                            "type": "string"
+                          },
                           "created_at": {
                             "type": "string",
                             "format": "date-time"
@@ -4481,6 +4496,7 @@
                       "author_name": "ken",
                       "organization_name": "CoderPad",
                       "custom_files": [],
+                      "ai_assist_custom_system_prompt": "Only provide hints.",
                       "created_at": "2023-08-03T11:32:56Z",
                       "updated_at": "2023-08-03T11:32:56Z"
                     },

--- a/src/coderpad/_dict_types.py
+++ b/src/coderpad/_dict_types.py
@@ -189,6 +189,7 @@ class QuestionDict(TypedDict):
     contents_for_test_cases: NotRequired[str]
     test_cases: NotRequired[list[TestCaseDict]]
     custom_database: NotRequired[CustomDatabaseDict]
+    ai_assist_custom_system_prompt: NotRequired[str | None]
 
 
 class OrganizationUserDict(TypedDict):

--- a/src/coderpad/types.py
+++ b/src/coderpad/types.py
@@ -797,6 +797,7 @@ class Question:
     contents_for_test_cases: str | None = None
     test_cases: list[TestCase] | None = None
     custom_database: CustomDatabase | None = None
+    ai_assist_custom_system_prompt: str | None = None
 
     @classmethod
     def from_dict(
@@ -855,6 +856,9 @@ class Question:
             )
             if raw_custom_database is not None
             else None,
+            ai_assist_custom_system_prompt=data.get(
+                "ai_assist_custom_system_prompt",
+            ),
         )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ from coderpad.transports import TransportResponse
 
 _BASE_URL = "https://app.coderpad.io"
 _LIVE_VARIANT_ORGANIZATION_ID = 42
+_AI_ASSIST_CUSTOM_SYSTEM_PROMPT = "Only provide hints."
 
 
 @pytest.fixture(name="live_variant_organization_id")
@@ -29,7 +30,7 @@ def fixture_live_variant_response() -> Callable[
 ]:
     """Return synthetic examples of empirically observed API variants."""
 
-    def live_variant_response(*, url: str) -> TransportResponse:
+    def live_variant_response(*, method: str, url: str) -> TransportResponse:
         """Build a synthetic live-variant response for ``url``."""
         if url.endswith("/api/pad_environments/binary"):
             payload: dict[str, object] = {
@@ -62,6 +63,17 @@ def fixture_live_variant_response() -> Callable[
                 "teams": [],
                 "child_organizations": [],
             }
+        elif url.endswith("/api/questions/custom") or (
+            method == "POST" and url.endswith("/api/questions/")
+        ):
+            payload = _question_payload()
+        elif method == "GET" and url.endswith("/api/questions/"):
+            payload = {
+                "status": "OK",
+                "questions": [_question_payload()],
+                "next_page": None,
+                "total": 1,
+            }
         else:  # pragma: no cover
             msg = f"Unexpected test URL: {url}"
             raise AssertionError(msg)
@@ -72,6 +84,32 @@ def fixture_live_variant_response() -> Callable[
         )
 
     return live_variant_response
+
+
+def _question_payload() -> dict[str, object]:
+    """Return a question with an empirically observed AI Assist prompt."""
+    return {
+        "id": 42,
+        "title": "FizzBuzz",
+        "owner_email": "owner@example.com",
+        "language": "python",
+        "description": "Write FizzBuzz",
+        "candidate_instructions": [],
+        "contents": "def fizzbuzz(): ...",
+        "shared": False,
+        "used": 3,
+        "take_home": False,
+        "test_cases_enabled": False,
+        "solution": None,
+        "pad_type": "standard",
+        "is_draft": False,
+        "author_name": "Author",
+        "organization_name": "Org",
+        "custom_files": [],
+        "created_at": "2026-07-16T00:00:00Z",
+        "updated_at": "2026-07-16T00:00:00Z",
+        "ai_assist_custom_system_prompt": _AI_ASSIST_CUSTOM_SYSTEM_PROMPT,
+    }
 
 
 @pytest.fixture(name="openapi_spec")

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -356,8 +356,8 @@ class TestAsyncGetPadEnvironment:
             files: (dict[str, tuple[str, bytes, str]] | None) = None,
         ) -> TransportResponse:
             """Return synthetic live-response variants."""
-            del method, headers, params, data, files
-            return live_variant_response(url=url)
+            del headers, params, data, files
+            return live_variant_response(method=method, url=url)
 
         client = AsyncCoderPad(api_key="test-key", transport=_transport)
         environment = await client.pads.get_environment(
@@ -369,6 +369,19 @@ class TestAsyncGetPadEnvironment:
         organization = await client.organization.get()
         assert organization.id == live_variant_organization_id
         assert organization.single_sign_in_url is None
+
+        questions = [
+            await client.questions.get(question_id="custom"),
+            (await client.questions.list())[0],
+            await client.questions.create(
+                title="FizzBuzz",
+                language="python",
+            ),
+        ]
+        assert all(
+            question.ai_assist_custom_system_prompt == "Only provide hints."
+            for question in questions
+        )
 
 
 class TestAsyncGetPadHistory:
@@ -489,6 +502,9 @@ class TestAsyncListQuestions:
         """Questions can be listed."""
         result = await async_coderpad_client.questions.list()
         assert result.total >= 0
+        assert (
+            result[0].ai_assist_custom_system_prompt == "Only provide hints."
+        )
 
     @staticmethod
     @pytest.mark.asyncio
@@ -517,6 +533,7 @@ class TestAsyncCreateQuestion:
             language="python",
         )
         assert result.id
+        assert result.ai_assist_custom_system_prompt == "Only provide hints."
 
     @staticmethod
     @pytest.mark.asyncio
@@ -636,6 +653,7 @@ class TestAsyncGetQuestion:
             question_id="123",
         )
         assert result.id
+        assert result.ai_assist_custom_system_prompt == "Only provide hints."
 
 
 class TestAsyncUpdateQuestion:
@@ -861,6 +879,9 @@ class TestAsyncListOrganizationQuestions:
         """Organization questions can be listed."""
         result = await async_coderpad_client.organization.questions.list()
         assert result.total >= 0
+        assert (
+            result[0].ai_assist_custom_system_prompt == "Only provide hints."
+        )
 
     @staticmethod
     @pytest.mark.asyncio

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -556,8 +556,8 @@ class TestGetPadEnvironment:
             files: (dict[str, tuple[str, bytes, str]] | None) = None,
         ) -> TransportResponse:
             """Return synthetic live-response variants."""
-            del method, headers, params, data, files
-            return live_variant_response(url=url)
+            del headers, params, data, files
+            return live_variant_response(method=method, url=url)
 
         client = CoderPad(api_key="test-key", transport=_transport)
         environment = client.pads.get_environment(
@@ -569,6 +569,16 @@ class TestGetPadEnvironment:
         organization = client.organization.get()
         assert organization.id == live_variant_organization_id
         assert organization.single_sign_in_url is None
+
+        questions = [
+            client.questions.get(question_id="custom"),
+            client.questions.list()[0],
+            client.questions.create(title="FizzBuzz", language="python"),
+        ]
+        assert all(
+            question.ai_assist_custom_system_prompt == "Only provide hints."
+            for question in questions
+        )
 
 
 class TestGetPadHistory:
@@ -685,6 +695,9 @@ class TestListQuestions:
         """Questions can be listed."""
         result = coderpad_client.questions.list()
         assert result.total >= 0
+        assert (
+            result[0].ai_assist_custom_system_prompt == "Only provide hints."
+        )
 
     @staticmethod
     def test_list_questions_with_params(
@@ -711,6 +724,7 @@ class TestCreateQuestion:
             language="python",
         )
         assert result.id
+        assert result.ai_assist_custom_system_prompt == "Only provide hints."
 
     @staticmethod
     def test_create_question_all_params(
@@ -824,6 +838,7 @@ class TestGetQuestion:
             question_id="123",
         )
         assert result.id
+        assert result.ai_assist_custom_system_prompt == "Only provide hints."
 
 
 class TestUpdateQuestion:
@@ -1034,6 +1049,9 @@ class TestListOrganizationQuestions:
         """Organization questions can be listed."""
         result = coderpad_client.organization.questions.list()
         assert result.total >= 0
+        assert (
+            result[0].ai_assist_custom_system_prompt == "Only provide hints."
+        )
 
     @staticmethod
     def test_list_organization_questions_with_params(

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -222,6 +222,7 @@ def _question_dict() -> QuestionDict:
         "contents_for_test_cases": "test code",
         "test_cases": [_test_case_dict()],
         "custom_database": _custom_database_dict(),
+        "ai_assist_custom_system_prompt": "Only provide hints.",
     }
 
 
@@ -501,6 +502,23 @@ class TestQuestion:
         assert result.custom_database is not None
         assert result.custom_database.title == "Products"
         assert result.custom_database.schema_json.tables[0].columns[0].pk
+        assert result.ai_assist_custom_system_prompt == "Only provide hints."
+
+    @staticmethod
+    def test_from_dict_with_null_ai_assist_custom_system_prompt() -> None:
+        """A Question can have no custom AI Assist system prompt."""
+        data = _question_dict()
+        data["ai_assist_custom_system_prompt"] = None
+        result = Question.from_dict(data=data)
+        assert result.ai_assist_custom_system_prompt is None
+
+    @staticmethod
+    def test_from_dict_without_ai_assist_custom_system_prompt() -> None:
+        """A Question can omit its custom AI Assist system prompt."""
+        data = _question_dict()
+        del data["ai_assist_custom_system_prompt"]
+        result = Question.from_dict(data=data)
+        assert result.ai_assist_custom_system_prompt is None
 
     @staticmethod
     def test_from_dict_without_custom_database() -> None:


### PR DESCRIPTION
Closes #237.

Adds the optional `ai_assist_custom_system_prompt` field to `Question` decoding because the live API already returns it but the client discarded it.

Updates the OpenAPI-backed mocks for get, list, create, and organization-list responses so callers can test round-trip synchronization.

Tests cover present, null, and absent values plus synchronous and asynchronous response paths; the full suite passes with 151 tests and 100% coverage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive, backward-compatible response decoding and spec/test updates with no auth or write-path behavior changes in this diff.
> 
> **Overview**
> Adds optional **`ai_assist_custom_system_prompt`** to question API models so values returned by the live API are no longer dropped when questions are fetched or listed.
> 
> **`Question`** / **`QuestionDict`** gain the field, and **`Question.from_dict`** maps it with **`data.get`** so present strings, explicit **`null`**, and omitted keys all decode predictably (default **`None`**). **`openapi.json`** documents the property on get, list, create, and organization-list question payloads, with example values aligned to mocks.
> 
> Tests extend live-variant fixtures and sync/async client coverage to assert the prompt round-trips on get, list, create, and org question list paths, plus unit tests for present, null, and absent JSON.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb46355727539aaf5348cdab5f011017253937ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->