### PR TITLE
Add organization users endpoint

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,22 @@ Getting Started
        sys.stdout.write(listed_pad.title)
    org = client.organization.get()
    sys.stdout.write(org.organization_name)
+   for user in client.organization.users.list():
+       sys.stdout.write(user.email)
+
+The organization users endpoint also supports server-side email filtering:
+
+.. code-block:: python
+
+   """Filter organization users by email."""
+
+   from coderpad.client import CoderPad
+
+   client = CoderPad(api_key="your-api-key")
+   users = client.organization.users.list(email="person@example.com")
+
+The equivalent asynchronous operation is
+``await client.organization.users.list(email="person@example.com")``.
 
 Full Documentation
 ------------------

--- a/docs/source/api-reference.rst
+++ b/docs/source/api-reference.rst
@@ -5,6 +5,10 @@ API Reference
    :undoc-members:
    :members:
 
+.. automodule:: coderpad.async_client
+   :undoc-members:
+   :members:
+
 .. automodule:: coderpad.transports
    :undoc-members:
    :members:

--- a/newsfragments/228.change
+++ b/newsfragments/228.change
@@ -1,0 +1,2 @@
+Add synchronous and asynchronous organization user listing, with optional
+server-side email filtering.

--- a/src/coderpad/async_client.py
+++ b/src/coderpad/async_client.py
@@ -1,5 +1,6 @@
 """Async CoderPad Interview API client."""
 
+import builtins
 import json
 from collections.abc import Sequence
 from http import HTTPStatus
@@ -19,6 +20,7 @@ from coderpad.types import (
     Language,
     Organization,
     OrganizationStats,
+    OrganizationUser,
     Pad,
     PadEnvironment,
     PadEvent,
@@ -648,6 +650,37 @@ class AsyncOrganizationQuestionsNamespace(
 
 
 @beartype
+class AsyncOrganizationUsersNamespace(_AsyncNamespace):
+    """Namespace for async organization user operations."""
+
+    async def list(
+        self,
+        *,
+        email: str | None = None,
+    ) -> builtins.list[OrganizationUser]:
+        """Retrieve users in the organization.
+
+        Args:
+            email: Return only the user with this email address.
+
+        Returns:
+            The organization users matching the filter.
+        """
+        params: dict[str, str | int] = {}
+        if email is not None:
+            params["email"] = email
+        response = await self._request(
+            method="GET",
+            url="/api/organization/users",
+            params=params,
+        )
+        return [
+            OrganizationUser.from_dict(data=item)
+            for item in response.json()["users"]
+        ]
+
+
+@beartype
 class AsyncOrganizationNamespace(_AsyncNamespace):
     """Namespace for async organization operations."""
 
@@ -679,6 +712,13 @@ class AsyncOrganizationNamespace(_AsyncNamespace):
         )
         self.questions: AsyncOrganizationQuestionsNamespace = (
             AsyncOrganizationQuestionsNamespace(
+                transport=transport,
+                base_url=base_url,
+                headers=headers,
+            )
+        )
+        self.users: AsyncOrganizationUsersNamespace = (
+            AsyncOrganizationUsersNamespace(
                 transport=transport,
                 base_url=base_url,
                 headers=headers,

--- a/src/coderpad/client.py
+++ b/src/coderpad/client.py
@@ -1,5 +1,6 @@
 """CoderPad Interview API client."""
 
+import builtins
 import json
 from collections.abc import Sequence
 from http import HTTPStatus
@@ -19,6 +20,7 @@ from coderpad.types import (
     Language,
     Organization,
     OrganizationStats,
+    OrganizationUser,
     Pad,
     PadEnvironment,
     PadEvent,
@@ -640,6 +642,37 @@ class OrganizationQuestionsNamespace(_Namespace):
 
 
 @beartype
+class OrganizationUsersNamespace(_Namespace):
+    """Namespace for organization user operations."""
+
+    def list(
+        self,
+        *,
+        email: str | None = None,
+    ) -> builtins.list[OrganizationUser]:
+        """Retrieve users in the organization.
+
+        Args:
+            email: Return only the user with this email address.
+
+        Returns:
+            The organization users matching the filter.
+        """
+        params: dict[str, str | int] = {}
+        if email is not None:
+            params["email"] = email
+        response = self._request(
+            method="GET",
+            url="/api/organization/users",
+            params=params,
+        )
+        return [
+            OrganizationUser.from_dict(data=item)
+            for item in response.json()["users"]
+        ]
+
+
+@beartype
 class OrganizationNamespace(_Namespace):
     """Namespace for organization operations."""
 
@@ -673,6 +706,11 @@ class OrganizationNamespace(_Namespace):
                 base_url=base_url,
                 headers=headers,
             )
+        )
+        self.users: OrganizationUsersNamespace = OrganizationUsersNamespace(
+            transport=transport,
+            base_url=base_url,
+            headers=headers,
         )
 
     def get(self) -> Organization:

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -19,6 +19,7 @@ from coderpad.transports import (
 from coderpad.types import (
     CandidateInstruction,
     Language,
+    OrganizationUser,
     QuestionFileContent,
     SortOrder,
 )
@@ -896,6 +897,90 @@ class TestAsyncListOrganizationQuestions:
             page=1,
         )
         assert result.total >= 0
+
+
+class TestAsyncListOrganizationUsers:
+    """Tests for ``AsyncCoderPad.organization.users.list``."""
+
+    @staticmethod
+    @pytest.mark.asyncio
+    async def test_list_organization_users(
+        async_coderpad_client: AsyncCoderPad,
+    ) -> None:
+        """Organization users can be listed and decoded."""
+        result = await async_coderpad_client.organization.users.list()
+        assert result
+        assert all(isinstance(item, OrganizationUser) for item in result)
+
+    @staticmethod
+    @pytest.mark.asyncio
+    async def test_list_organization_users_with_email(
+        async_coderpad_client: AsyncCoderPad,
+        mock_coderpad_api: respx.MockRouter,
+    ) -> None:
+        """Organization users can be filtered by email."""
+        email = "buddy@company.io"
+        result = await async_coderpad_client.organization.users.list(
+            email=email,
+        )
+        request = mock_coderpad_api.calls.last.request
+        assert request.url.params["email"] == email
+        assert all(isinstance(item, OrganizationUser) for item in result)
+
+    @staticmethod
+    @pytest.mark.asyncio
+    async def test_list_organization_users_empty() -> None:
+        """An empty organization user response decodes to an empty
+        list.
+        """
+
+        async def _empty_transport(
+            *,
+            method: str,
+            url: str,
+            headers: dict[str, str],
+            params: (dict[str, str | int] | None) = None,
+            data: dict[str, str] | None = None,
+            files: (dict[str, tuple[str, bytes, str]] | None) = None,
+        ) -> TransportResponse:
+            """Return an empty successful user response."""
+            del method, url, headers, params, data, files
+            return TransportResponse(
+                status_code=HTTPStatus.OK,
+                headers={},
+                content=b'{"status": "OK", "users": []}',
+            )
+
+        client = AsyncCoderPad(api_key="test-key", transport=_empty_transport)
+        assert await client.organization.users.list() == []
+
+    @staticmethod
+    @pytest.mark.asyncio
+    async def test_list_organization_users_maps_http_errors() -> None:
+        """Organization user HTTP failures use the client error
+        hierarchy.
+        """
+
+        async def _error_transport(
+            *,
+            method: str,
+            url: str,
+            headers: dict[str, str],
+            params: (dict[str, str | int] | None) = None,
+            data: dict[str, str] | None = None,
+            files: (dict[str, tuple[str, bytes, str]] | None) = None,
+        ) -> TransportResponse:
+            """Return a not-found user response."""
+            del method, url, headers, params, data, files
+            return TransportResponse(
+                status_code=HTTPStatus.NOT_FOUND,
+                headers={},
+                content=b"Not Found",
+            )
+
+        client = AsyncCoderPad(api_key="test-key", transport=_error_transport)
+        with pytest.raises(expected_exception=NotFoundError):
+            await client.organization.users.list()
 
 
 class TestAsyncExceptionHandling:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -28,6 +28,7 @@ from coderpad.transports import (
 from coderpad.types import (
     CandidateInstruction,
     Language,
+    OrganizationUser,
     QuestionFileContent,
     SortOrder,
 )
@@ -1065,3 +1066,81 @@ class TestListOrganizationQuestions:
             page=1,
         )
         assert result.total >= 0
+
+
+class TestListOrganizationUsers:
+    """Tests for ``CoderPad.organization.users.list``."""
+
+    @staticmethod
+    def test_list_organization_users(
+        coderpad_client: CoderPad,
+    ) -> None:
+        """Organization users can be listed and decoded."""
+        result = coderpad_client.organization.users.list()
+        assert result
+        assert all(isinstance(item, OrganizationUser) for item in result)
+
+    @staticmethod
+    def test_list_organization_users_with_email(
+        coderpad_client: CoderPad,
+        mock_coderpad_api: respx.MockRouter,
+    ) -> None:
+        """Organization users can be filtered by email."""
+        email = "buddy@company.io"
+        result = coderpad_client.organization.users.list(email=email)
+        request = mock_coderpad_api.calls.last.request
+        assert request.url.params["email"] == email
+        assert all(isinstance(item, OrganizationUser) for item in result)
+
+    @staticmethod
+    def test_list_organization_users_empty() -> None:
+        """An empty organization user response decodes to an empty
+        list.
+        """
+
+        def _empty_transport(
+            *,
+            method: str,
+            url: str,
+            headers: dict[str, str],
+            params: dict[str, str | int] | None = None,
+            data: dict[str, str] | None = None,
+            files: (dict[str, tuple[str, bytes, str]] | None) = None,
+        ) -> TransportResponse:
+            """Return an empty successful user response."""
+            del method, url, headers, params, data, files
+            return TransportResponse(
+                status_code=HTTPStatus.OK,
+                headers={},
+                content=b'{"status": "OK", "users": []}',
+            )
+
+        client = CoderPad(api_key="test-key", transport=_empty_transport)
+        assert client.organization.users.list() == []
+
+    @staticmethod
+    def test_list_organization_users_maps_http_errors() -> None:
+        """Organization user HTTP failures use the client error
+        hierarchy.
+        """
+
+        def _error_transport(
+            *,
+            method: str,
+            url: str,
+            headers: dict[str, str],
+            params: dict[str, str | int] | None = None,
+            data: dict[str, str] | None = None,
+            files: (dict[str, tuple[str, bytes, str]] | None) = None,
+        ) -> TransportResponse:
+            """Return a not-found user response."""
+            del method, url, headers, params, data, files
+            return TransportResponse(
+                status_code=HTTPStatus.NOT_FOUND,
+                headers={},
+                content=b"Not Found",
+            )
+
+        client = CoderPad(api_key="test-key", transport=_error_transport)
+        with pytest.raises(expected_exception=NotFoundError):
+            client.organization.users.list()


### PR DESCRIPTION
## Summary

- add synchronous and asynchronous `organization.users.list()` operations
- support optional server-side filtering with the `email` query parameter
- decode responses into the existing `OrganizationUser` model
- document the new operation and add a changelog fragment

## Impact

Users can now retrieve all organization users, or filter for a specific email
address, from either client without making raw HTTP requests.

## Validation

- `uv run --extra dev pytest -q` (160 passed)
- `uv run --extra dev prek run --all-files`

Closes #228

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive read-only API surface following existing organization namespace patterns; no changes to auth or existing endpoints.
> 
> **Overview**
> Adds **`organization.users.list()`** on both **`CoderPad`** and **`AsyncCoderPad`**, wired through new `OrganizationUsersNamespace` / `AsyncOrganizationUsersNamespace` that call `GET /api/organization/users` and map the `users` array to existing **`OrganizationUser`** models.
> 
> Optional **`email`** is sent as a query parameter for server-side filtering. README examples, API reference coverage for **`async_client`**, a newsfragment, and sync/async tests (including empty responses and HTTP error mapping) round out the change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5436616d23a753c5e9ad4519fe01e79e4de06fa5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->