### PR TITLE
Add CoderPad Screen API support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,6 +49,31 @@ The organization users endpoint also supports server-side email filtering:
 The equivalent asynchronous operation is
 ``await client.organization.users.list(email="person@example.com")``.
 
+CoderPad Screen
+---------------
+
+Screen uses a separate API key and host from Interview:
+
+.. code-block:: python
+
+   """List Screen campaigns and candidate tests."""
+
+   from coderpad import CoderPad
+
+   client = CoderPad(
+       api_key="your-interview-api-key",
+       screen_api_key="your-screen-api-key",
+   )
+   campaigns = client.screen.campaigns.list()
+   page = client.screen.tests.list(campaign_id=campaigns[0].id, limit=50)
+   assert page.pagination is not None
+
+Screen test listings use offset pagination. While
+``page.pagination.has_more_items`` is true, request the next page with
+``start=page.pagination.next_start``. Use ``SCREEN_EU_BASE_URL`` as
+``screen_base_url`` for EU-hosted organizations. All Screen operations have
+equivalent methods on ``AsyncCoderPad``.
+
 Full Documentation
 ------------------
 

--- a/conftest.py
+++ b/conftest.py
@@ -34,6 +34,25 @@ def fixture_mock_coderpad_api(
             spec=openapi_spec,
             base_url=_BASE_URL,
         )
+        mock_router.get(
+            url="https://www.codingame.com/assessment/api/v1.1/campaigns",
+        ).respond(
+            json=[{"id": 1, "name": "Example campaign"}],
+        )
+        mock_router.get(
+            url="https://www.codingame.com/assessment/api/v1.1/tests",
+        ).respond(
+            json={
+                "tests": [],
+                "pagination": {
+                    "start": 0,
+                    "limit": 50,
+                    "total": 0,
+                    "has_more_items": False,
+                    "next_start": None,
+                },
+            },
+        )
         yield mock_router
 
 

--- a/docs/source/api-reference.rst
+++ b/docs/source/api-reference.rst
@@ -9,6 +9,18 @@ API Reference
    :undoc-members:
    :members:
 
+.. automodule:: coderpad.screen
+   :undoc-members:
+   :members:
+
+.. automodule:: coderpad.async_screen
+   :undoc-members:
+   :members:
+
+.. automodule:: coderpad.screen_types
+   :undoc-members:
+   :members:
+
 .. automodule:: coderpad.transports
    :undoc-members:
    :members:

--- a/newsfragments/227.change
+++ b/newsfragments/227.change
@@ -1,0 +1,2 @@
+Add typed synchronous and asynchronous CoderPad Screen clients covering
+campaigns, invitations, tests, reports, pagination, regions, and webhooks.

--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -25,6 +25,7 @@ linting
 macOS
 metadata
 namespace
+namespaces
 noqa
 params
 pluggable
@@ -45,4 +46,6 @@ todo
 txt
 unmapped
 url
+webhook
+webhooks
 yml

--- a/src/coderpad/__init__.py
+++ b/src/coderpad/__init__.py
@@ -1,1 +1,36 @@
-"""A library for the CoderPad Interview API."""
+"""A library for the CoderPad Interview and Screen APIs."""
+
+from coderpad.async_client import AsyncCoderPad
+from coderpad.client import CoderPad
+from coderpad.screen import SCREEN_EU_BASE_URL, SCREEN_US_BASE_URL
+from coderpad.screen_types import (
+    ScreenCampaign,
+    ScreenInvitation,
+    ScreenInvitationResult,
+    ScreenPagination,
+    ScreenReport,
+    ScreenSkillResult,
+    ScreenTechnologyResult,
+    ScreenTest,
+    ScreenTestQuestion,
+    ScreenTestsPage,
+    ScreenWebhook,
+)
+
+__all__ = [
+    "SCREEN_EU_BASE_URL",
+    "SCREEN_US_BASE_URL",
+    "AsyncCoderPad",
+    "CoderPad",
+    "ScreenCampaign",
+    "ScreenInvitation",
+    "ScreenInvitationResult",
+    "ScreenPagination",
+    "ScreenReport",
+    "ScreenSkillResult",
+    "ScreenTechnologyResult",
+    "ScreenTest",
+    "ScreenTestQuestion",
+    "ScreenTestsPage",
+    "ScreenWebhook",
+]

--- a/src/coderpad/async_client.py
+++ b/src/coderpad/async_client.py
@@ -14,6 +14,7 @@ from coderpad.exceptions import CoderPadError
 from coderpad.screen import SCREEN_US_BASE_URL
 from coderpad.transports import (
     AsyncHTTPXTransport,
+    AsyncJSONTransport,
     AsyncTransport,
     TransportResponse,
 )
@@ -796,6 +797,7 @@ class AsyncCoderPad:
         screen_api_key: str | None = None,
         screen_base_url: str = SCREEN_US_BASE_URL,
         transport: AsyncTransport | None = None,
+        screen_transport: AsyncJSONTransport | None = None,
     ) -> None:
         """Create a new async CoderPad client.
 
@@ -806,9 +808,11 @@ class AsyncCoderPad:
             screen_base_url: The US, EU, or custom Screen base URL.
             transport: The async HTTP transport. Defaults
                 to ``AsyncHTTPXTransport()``.
+            screen_transport: The independent Screen HTTP transport.
         """
         self.base_url = base_url
         resolved_transport = transport or AsyncHTTPXTransport()
+        resolved_screen_transport = screen_transport or AsyncHTTPXTransport()
         headers = {"Authorization": f'Token token="{api_key}"'}
         self.pads: AsyncPadsNamespace = AsyncPadsNamespace(
             transport=resolved_transport,
@@ -821,7 +825,7 @@ class AsyncCoderPad:
             headers=headers,
         )
         self.screen: AsyncScreenNamespace = AsyncScreenNamespace(
-            transport=resolved_transport,
+            transport=resolved_screen_transport,
             api_key=screen_api_key or "",
             base_url=screen_base_url,
         )
@@ -836,6 +840,14 @@ class AsyncCoderPad:
                 """No-op close for transports without aclose."""
 
             self._aclose = _noop
+        if isinstance(resolved_screen_transport, AsyncHTTPXTransport):
+            self._screen_aclose = resolved_screen_transport.aclose
+        else:
+
+            async def _screen_noop() -> None:
+                """No-op close for Screen transports without aclose."""
+
+            self._screen_aclose = _screen_noop
         self.organization: AsyncOrganizationNamespace = (
             AsyncOrganizationNamespace(
                 transport=resolved_transport,
@@ -847,6 +859,7 @@ class AsyncCoderPad:
     async def aclose(self) -> None:
         """Close the underlying transport."""
         await self._aclose()
+        await self._screen_aclose()
 
     async def __aenter__(self) -> Self:
         """Enter the async context manager.

--- a/src/coderpad/async_client.py
+++ b/src/coderpad/async_client.py
@@ -9,7 +9,9 @@ from typing import Self
 
 from beartype import beartype
 
+from coderpad.async_screen import AsyncScreenNamespace
 from coderpad.exceptions import CoderPadError
+from coderpad.screen import SCREEN_US_BASE_URL
 from coderpad.transports import (
     AsyncHTTPXTransport,
     AsyncTransport,
@@ -791,6 +793,8 @@ class AsyncCoderPad:
         *,
         api_key: str,
         base_url: str = ("https://app.coderpad.io"),
+        screen_api_key: str | None = None,
+        screen_base_url: str = SCREEN_US_BASE_URL,
         transport: AsyncTransport | None = None,
     ) -> None:
         """Create a new async CoderPad client.
@@ -798,6 +802,8 @@ class AsyncCoderPad:
         Args:
             api_key: The API key for authentication.
             base_url: The base URL for the API.
+            screen_api_key: The independent Screen API key.
+            screen_base_url: The US, EU, or custom Screen base URL.
             transport: The async HTTP transport. Defaults
                 to ``AsyncHTTPXTransport()``.
         """
@@ -813,6 +819,11 @@ class AsyncCoderPad:
             transport=resolved_transport,
             base_url=base_url,
             headers=headers,
+        )
+        self.screen: AsyncScreenNamespace = AsyncScreenNamespace(
+            transport=resolved_transport,
+            api_key=screen_api_key or "",
+            base_url=screen_base_url,
         )
         if isinstance(
             resolved_transport,

--- a/src/coderpad/async_screen.py
+++ b/src/coderpad/async_screen.py
@@ -1,0 +1,246 @@
+"""Asynchronous CoderPad Screen API namespaces."""
+
+import builtins
+from http import HTTPStatus
+
+from beartype import beartype
+
+from coderpad.exceptions import CoderPadError
+from coderpad.screen import SCREEN_US_BASE_URL
+from coderpad.screen_types import (
+    ScreenCampaign,
+    ScreenInvitation,
+    ScreenInvitationResult,
+    ScreenTest,
+    ScreenTestsPage,
+    ScreenWebhook,
+)
+from coderpad.transports import AsyncTransport, TransportResponse
+
+_SCREEN_PREFIX = "/assessment/api/v1.1"
+
+
+@beartype
+class _AsyncScreenNamespace:
+    """Shared asynchronous Screen request handling."""
+
+    def __init__(
+        self,
+        *,
+        transport: AsyncTransport,
+        api_key: str,
+        base_url: str = SCREEN_US_BASE_URL,
+    ) -> None:
+        """Create shared asynchronous Screen request state."""
+        self.transport = transport
+        self.base_url = base_url.rstrip("/")
+        self.headers = {"API-Key": api_key}
+
+    async def _request(
+        self,
+        *,
+        method: str,
+        path: str,
+        params: dict[str, str | int] | None = None,
+        json: object | None = None,
+    ) -> TransportResponse:
+        """Make a Screen request and map HTTP failures."""
+        response = await self.transport(
+            method=method,
+            url=self.base_url + _SCREEN_PREFIX + path,
+            headers=self.headers,
+            params=params,
+            json=json,
+        )
+        if response.status_code >= HTTPStatus.BAD_REQUEST:
+            raise CoderPadError.from_response(response=response)
+        return response
+
+
+@beartype
+class AsyncScreenCampaignsNamespace(_AsyncScreenNamespace):
+    """Asynchronous Screen campaign operations."""
+
+    async def list(self) -> builtins.list[ScreenCampaign]:
+        """List assessment campaigns."""
+        response = await self._request(method="GET", path="/campaigns")
+        return [
+            ScreenCampaign.from_dict(data=item)
+            for item in response.json()
+            if isinstance(item, dict)
+        ]
+
+    async def send_invitation(
+        self,
+        *,
+        campaign_id: int,
+        invitation: ScreenInvitation,
+    ) -> ScreenInvitationResult:
+        """Create a test session and optionally email the candidate."""
+        response = await self._request(
+            method="POST",
+            path=f"/campaigns/{campaign_id}/actions/send",
+            json=invitation.to_dict(),
+        )
+        return ScreenInvitationResult.from_dict(data=response.json())
+
+
+@beartype
+class AsyncScreenTestsNamespace(_AsyncScreenNamespace):
+    """Asynchronous Screen test-session operations."""
+
+    async def list(
+        self,
+        *,
+        campaign_id: int | None = None,
+        status: str | None = None,
+        tag: str | None = None,
+        search: str | None = None,
+        product: str | None = None,
+        candidate_email: str | None = None,
+        from_time: int | None = None,
+        to_time: int | None = None,
+        start: int | None = None,
+        limit: int | None = None,
+    ) -> ScreenTestsPage:
+        """List one offset-paginated page of tests.
+
+        Pass ``page.pagination.next_start`` to ``start`` while
+        ``has_more_items`` is true to traverse subsequent pages.
+        """
+        params: dict[str, str | int] = {}
+        values: tuple[tuple[str, str | int | None], ...] = (
+            ("campaignId", campaign_id),
+            ("status", status),
+            ("tag", tag),
+            ("search", search),
+            ("product", product),
+            ("candidateEmail", candidate_email),
+            ("from", from_time),
+            ("to", to_time),
+            ("start", start),
+            ("limit", limit),
+        )
+        params.update(
+            (key, value) for key, value in values if value is not None
+        )
+        response = await self._request(
+            method="GET",
+            path="/tests",
+            params=params,
+        )
+        return ScreenTestsPage.from_dict(data=response.json())
+
+    async def get(
+        self,
+        *,
+        test_id: int,
+        with_community_stats: bool = False,
+    ) -> ScreenTest:
+        """Retrieve one test session."""
+        params = {"withCommunityStats": "true"} if with_community_stats else {}
+        response = await self._request(
+            method="GET",
+            path=f"/tests/{test_id}",
+            params=params,
+        )
+        return ScreenTest.from_dict(data=response.json())
+
+    async def cancel(self, *, test_id: int) -> None:
+        """Cancel a test invitation."""
+        await self._request(
+            method="POST",
+            path=f"/tests/{test_id}/actions/cancel",
+        )
+
+    async def resend(self, *, test_id: int) -> None:
+        """Resend a test invitation."""
+        await self._request(
+            method="POST",
+            path=f"/tests/{test_id}/actions/resend",
+        )
+
+    async def delete(self, *, test_id: int) -> None:
+        """Delete a test session."""
+        await self._request(method="DELETE", path=f"/tests/{test_id}")
+
+    async def report(
+        self,
+        *,
+        test_id: int,
+        report_type: str | None = None,
+        anonymous: bool | None = None,
+        include_rank: bool | None = None,
+        include_comparative_score: bool | None = None,
+    ) -> bytes:
+        """Download a test report without writing it to disk."""
+        params: dict[str, str | int] = {}
+        values: tuple[tuple[str, str | bool | None], ...] = (
+            ("report_type", report_type),
+            ("anonymous", anonymous),
+            ("include_rank", include_rank),
+            ("include_comparative_score", include_comparative_score),
+        )
+        for key, value in values:
+            if isinstance(value, bool):
+                params[key] = "true" if value else "false"
+            elif value is not None:
+                params[key] = value
+        response = await self._request(
+            method="GET",
+            path=f"/tests/{test_id}/report",
+            params=params,
+        )
+        return response.content
+
+
+@beartype
+class AsyncScreenWebhookNamespace(_AsyncScreenNamespace):
+    """Asynchronous Screen webhook operations."""
+
+    async def get(self) -> ScreenWebhook:
+        """Retrieve webhook configuration."""
+        response = await self._request(method="GET", path="/webhook")
+        return ScreenWebhook.from_dict(data=response.json())
+
+    async def set(self, *, url: str) -> None:
+        """Set or replace the webhook URL."""
+        await self._request(method="POST", path="/webhook", json=url)
+
+    async def delete(self) -> None:
+        """Delete the webhook configuration."""
+        await self._request(method="DELETE", path="/webhook")
+
+
+@beartype
+class AsyncScreenNamespace(_AsyncScreenNamespace):
+    """Root namespace for the asynchronous Screen API."""
+
+    def __init__(
+        self,
+        *,
+        transport: AsyncTransport,
+        api_key: str,
+        base_url: str = SCREEN_US_BASE_URL,
+    ) -> None:
+        """Create the root asynchronous Screen namespace."""
+        super().__init__(
+            transport=transport,
+            api_key=api_key,
+            base_url=base_url,
+        )
+        self.campaigns = AsyncScreenCampaignsNamespace(
+            transport=transport,
+            api_key=api_key,
+            base_url=base_url,
+        )
+        self.tests = AsyncScreenTestsNamespace(
+            transport=transport,
+            api_key=api_key,
+            base_url=base_url,
+        )
+        self.webhook = AsyncScreenWebhookNamespace(
+            transport=transport,
+            api_key=api_key,
+            base_url=base_url,
+        )

--- a/src/coderpad/async_screen.py
+++ b/src/coderpad/async_screen.py
@@ -15,7 +15,7 @@ from coderpad.screen_types import (
     ScreenTestsPage,
     ScreenWebhook,
 )
-from coderpad.transports import AsyncTransport, TransportResponse
+from coderpad.transports import AsyncJSONTransport, TransportResponse
 
 _SCREEN_PREFIX = "/assessment/api/v1.1"
 
@@ -27,14 +27,14 @@ class _AsyncScreenNamespace:
     def __init__(
         self,
         *,
-        transport: AsyncTransport,
+        transport: AsyncJSONTransport,
         api_key: str,
         base_url: str = SCREEN_US_BASE_URL,
     ) -> None:
         """Create shared asynchronous Screen request state."""
-        self.transport = transport
-        self.base_url = base_url.rstrip("/")
-        self.headers = {"API-Key": api_key}
+        self.transport: AsyncJSONTransport = transport
+        self.base_url: str = base_url.rstrip("/")
+        self.headers: dict[str, str] = {"API-Key": api_key}
 
     async def _request(
         self,
@@ -64,11 +64,8 @@ class AsyncScreenCampaignsNamespace(_AsyncScreenNamespace):
     async def list(self) -> builtins.list[ScreenCampaign]:
         """List assessment campaigns."""
         response = await self._request(method="GET", path="/campaigns")
-        return [
-            ScreenCampaign.from_dict(data=item)
-            for item in response.json()
-            if isinstance(item, dict)
-        ]
+        raw_campaigns: object = response.json()
+        return ScreenCampaign.list_from_value(value=raw_campaigns)
 
     async def send_invitation(
         self,
@@ -138,7 +135,9 @@ class AsyncScreenTestsNamespace(_AsyncScreenNamespace):
         with_community_stats: bool = False,
     ) -> ScreenTest:
         """Retrieve one test session."""
-        params = {"withCommunityStats": "true"} if with_community_stats else {}
+        params: dict[str, str | int] = (
+            {"withCommunityStats": "true"} if with_community_stats else {}
+        )
         response = await self._request(
             method="GET",
             path=f"/tests/{test_id}",
@@ -219,7 +218,7 @@ class AsyncScreenNamespace(_AsyncScreenNamespace):
     def __init__(
         self,
         *,
-        transport: AsyncTransport,
+        transport: AsyncJSONTransport,
         api_key: str,
         base_url: str = SCREEN_US_BASE_URL,
     ) -> None:
@@ -229,18 +228,22 @@ class AsyncScreenNamespace(_AsyncScreenNamespace):
             api_key=api_key,
             base_url=base_url,
         )
-        self.campaigns = AsyncScreenCampaignsNamespace(
+        self.campaigns: AsyncScreenCampaignsNamespace = (
+            AsyncScreenCampaignsNamespace(
+                transport=transport,
+                api_key=api_key,
+                base_url=base_url,
+            )
+        )
+        self.tests: AsyncScreenTestsNamespace = AsyncScreenTestsNamespace(
             transport=transport,
             api_key=api_key,
             base_url=base_url,
         )
-        self.tests = AsyncScreenTestsNamespace(
-            transport=transport,
-            api_key=api_key,
-            base_url=base_url,
-        )
-        self.webhook = AsyncScreenWebhookNamespace(
-            transport=transport,
-            api_key=api_key,
-            base_url=base_url,
+        self.webhook: AsyncScreenWebhookNamespace = (
+            AsyncScreenWebhookNamespace(
+                transport=transport,
+                api_key=api_key,
+                base_url=base_url,
+            )
         )

--- a/src/coderpad/client.py
+++ b/src/coderpad/client.py
@@ -10,6 +10,7 @@ from typing import Self
 from beartype import beartype
 
 from coderpad.exceptions import CoderPadError
+from coderpad.screen import SCREEN_US_BASE_URL, ScreenNamespace
 from coderpad.transports import (
     HTTPXTransport,
     Transport,
@@ -778,6 +779,8 @@ class CoderPad:
         *,
         api_key: str,
         base_url: str = "https://app.coderpad.io",
+        screen_api_key: str | None = None,
+        screen_base_url: str = SCREEN_US_BASE_URL,
         transport: Transport | None = None,
     ) -> None:
         """Create a new CoderPad client.
@@ -785,6 +788,8 @@ class CoderPad:
         Args:
             api_key: The API key for authentication.
             base_url: The base URL for the API.
+            screen_api_key: The independent Screen API key.
+            screen_base_url: The US, EU, or custom Screen base URL.
             transport: The HTTP transport. Defaults to
                 ``HTTPXTransport()``.
         """
@@ -800,6 +805,11 @@ class CoderPad:
             transport=resolved_transport,
             base_url=base_url,
             headers=headers,
+        )
+        self.screen: ScreenNamespace = ScreenNamespace(
+            transport=resolved_transport,
+            api_key=screen_api_key or "",
+            base_url=screen_base_url,
         )
         if isinstance(resolved_transport, HTTPXTransport):
             self._close = resolved_transport.close

--- a/src/coderpad/client.py
+++ b/src/coderpad/client.py
@@ -13,6 +13,7 @@ from coderpad.exceptions import CoderPadError
 from coderpad.screen import SCREEN_US_BASE_URL, ScreenNamespace
 from coderpad.transports import (
     HTTPXTransport,
+    JSONTransport,
     Transport,
     TransportResponse,
 )
@@ -782,6 +783,7 @@ class CoderPad:
         screen_api_key: str | None = None,
         screen_base_url: str = SCREEN_US_BASE_URL,
         transport: Transport | None = None,
+        screen_transport: JSONTransport | None = None,
     ) -> None:
         """Create a new CoderPad client.
 
@@ -792,9 +794,11 @@ class CoderPad:
             screen_base_url: The US, EU, or custom Screen base URL.
             transport: The HTTP transport. Defaults to
                 ``HTTPXTransport()``.
+            screen_transport: The independent Screen HTTP transport.
         """
         self.base_url = base_url
         resolved_transport = transport or HTTPXTransport()
+        resolved_screen_transport = screen_transport or HTTPXTransport()
         headers = {"Authorization": f'Token token="{api_key}"'}
         self.pads: PadsNamespace = PadsNamespace(
             transport=resolved_transport,
@@ -807,7 +811,7 @@ class CoderPad:
             headers=headers,
         )
         self.screen: ScreenNamespace = ScreenNamespace(
-            transport=resolved_transport,
+            transport=resolved_screen_transport,
             api_key=screen_api_key or "",
             base_url=screen_base_url,
         )
@@ -815,6 +819,10 @@ class CoderPad:
             self._close = resolved_transport.close
         else:
             self._close = lambda: None
+        if isinstance(resolved_screen_transport, HTTPXTransport):
+            self._screen_close = resolved_screen_transport.close
+        else:
+            self._screen_close = lambda: None
         self.organization: OrganizationNamespace = OrganizationNamespace(
             transport=resolved_transport,
             base_url=base_url,
@@ -824,6 +832,7 @@ class CoderPad:
     def close(self) -> None:
         """Close the underlying transport if it supports closing."""
         self._close()
+        self._screen_close()
 
     def __enter__(self) -> Self:
         """Enter the context manager.

--- a/src/coderpad/screen.py
+++ b/src/coderpad/screen.py
@@ -1,0 +1,236 @@
+"""Synchronous CoderPad Screen API namespaces."""
+
+import builtins
+from http import HTTPStatus
+
+from beartype import beartype
+
+from coderpad.exceptions import CoderPadError
+from coderpad.screen_types import (
+    ScreenCampaign,
+    ScreenInvitation,
+    ScreenInvitationResult,
+    ScreenTest,
+    ScreenTestsPage,
+    ScreenWebhook,
+)
+from coderpad.transports import Transport, TransportResponse
+
+SCREEN_US_BASE_URL = "https://www.codingame.com"
+SCREEN_EU_BASE_URL = "https://www.codingame.eu"
+_SCREEN_PREFIX = "/assessment/api/v1.1"
+
+
+@beartype
+class _ScreenNamespace:
+    """Shared synchronous Screen request handling."""
+
+    def __init__(
+        self,
+        *,
+        transport: Transport,
+        api_key: str,
+        base_url: str,
+    ) -> None:
+        """Create shared Screen request state."""
+        self.transport = transport
+        self.base_url = base_url.rstrip("/")
+        self.headers = {"API-Key": api_key}
+
+    def _request(
+        self,
+        *,
+        method: str,
+        path: str,
+        params: dict[str, str | int] | None = None,
+        json: object | None = None,
+    ) -> TransportResponse:
+        """Make a Screen request and map HTTP failures."""
+        response = self.transport(
+            method=method,
+            url=self.base_url + _SCREEN_PREFIX + path,
+            headers=self.headers,
+            params=params,
+            json=json,
+        )
+        if response.status_code >= HTTPStatus.BAD_REQUEST:
+            raise CoderPadError.from_response(response=response)
+        return response
+
+
+@beartype
+class ScreenCampaignsNamespace(_ScreenNamespace):
+    """Screen campaign operations."""
+
+    def list(self) -> builtins.list[ScreenCampaign]:
+        """List assessment campaigns."""
+        response = self._request(method="GET", path="/campaigns")
+        return [
+            ScreenCampaign.from_dict(data=item)
+            for item in response.json()
+            if isinstance(item, dict)
+        ]
+
+    def send_invitation(
+        self,
+        *,
+        campaign_id: int,
+        invitation: ScreenInvitation,
+    ) -> ScreenInvitationResult:
+        """Create a test session and optionally email the candidate."""
+        response = self._request(
+            method="POST",
+            path=f"/campaigns/{campaign_id}/actions/send",
+            json=invitation.to_dict(),
+        )
+        return ScreenInvitationResult.from_dict(data=response.json())
+
+
+@beartype
+class ScreenTestsNamespace(_ScreenNamespace):
+    """Screen test-session operations."""
+
+    def list(
+        self,
+        *,
+        campaign_id: int | None = None,
+        status: str | None = None,
+        tag: str | None = None,
+        search: str | None = None,
+        product: str | None = None,
+        candidate_email: str | None = None,
+        from_time: int | None = None,
+        to_time: int | None = None,
+        start: int | None = None,
+        limit: int | None = None,
+    ) -> ScreenTestsPage:
+        """List one offset-paginated page of tests.
+
+        Pass ``page.pagination.next_start`` to ``start`` while
+        ``has_more_items`` is true to traverse subsequent pages.
+        """
+        params: dict[str, str | int] = {}
+        values: tuple[tuple[str, str | int | None], ...] = (
+            ("campaignId", campaign_id),
+            ("status", status),
+            ("tag", tag),
+            ("search", search),
+            ("product", product),
+            ("candidateEmail", candidate_email),
+            ("from", from_time),
+            ("to", to_time),
+            ("start", start),
+            ("limit", limit),
+        )
+        params.update(
+            (key, value) for key, value in values if value is not None
+        )
+        response = self._request(method="GET", path="/tests", params=params)
+        return ScreenTestsPage.from_dict(data=response.json())
+
+    def get(
+        self,
+        *,
+        test_id: int,
+        with_community_stats: bool = False,
+    ) -> ScreenTest:
+        """Retrieve one test session."""
+        params = {"withCommunityStats": "true"} if with_community_stats else {}
+        response = self._request(
+            method="GET",
+            path=f"/tests/{test_id}",
+            params=params,
+        )
+        return ScreenTest.from_dict(data=response.json())
+
+    def cancel(self, *, test_id: int) -> None:
+        """Cancel a test invitation."""
+        self._request(method="POST", path=f"/tests/{test_id}/actions/cancel")
+
+    def resend(self, *, test_id: int) -> None:
+        """Resend a test invitation."""
+        self._request(method="POST", path=f"/tests/{test_id}/actions/resend")
+
+    def delete(self, *, test_id: int) -> None:
+        """Delete a test session."""
+        self._request(method="DELETE", path=f"/tests/{test_id}")
+
+    def report(
+        self,
+        *,
+        test_id: int,
+        report_type: str | None = None,
+        anonymous: bool | None = None,
+        include_rank: bool | None = None,
+        include_comparative_score: bool | None = None,
+    ) -> bytes:
+        """Download a test report without writing it to disk."""
+        params: dict[str, str | int] = {}
+        values: tuple[tuple[str, str | bool | None], ...] = (
+            ("report_type", report_type),
+            ("anonymous", anonymous),
+            ("include_rank", include_rank),
+            ("include_comparative_score", include_comparative_score),
+        )
+        for key, value in values:
+            if isinstance(value, bool):
+                params[key] = "true" if value else "false"
+            elif value is not None:
+                params[key] = value
+        return self._request(
+            method="GET",
+            path=f"/tests/{test_id}/report",
+            params=params,
+        ).content
+
+
+@beartype
+class ScreenWebhookNamespace(_ScreenNamespace):
+    """Screen webhook operations."""
+
+    def get(self) -> ScreenWebhook:
+        """Retrieve webhook configuration."""
+        response = self._request(method="GET", path="/webhook")
+        return ScreenWebhook.from_dict(data=response.json())
+
+    def set(self, *, url: str) -> None:
+        """Set or replace the webhook URL."""
+        self._request(method="POST", path="/webhook", json=url)
+
+    def delete(self) -> None:
+        """Delete the webhook configuration."""
+        self._request(method="DELETE", path="/webhook")
+
+
+@beartype
+class ScreenNamespace(_ScreenNamespace):
+    """Root namespace for the synchronous Screen API."""
+
+    def __init__(
+        self,
+        *,
+        transport: Transport,
+        api_key: str,
+        base_url: str,
+    ) -> None:
+        """Create the root Screen namespace."""
+        super().__init__(
+            transport=transport,
+            api_key=api_key,
+            base_url=base_url,
+        )
+        self.campaigns = ScreenCampaignsNamespace(
+            transport=transport,
+            api_key=api_key,
+            base_url=base_url,
+        )
+        self.tests = ScreenTestsNamespace(
+            transport=transport,
+            api_key=api_key,
+            base_url=base_url,
+        )
+        self.webhook = ScreenWebhookNamespace(
+            transport=transport,
+            api_key=api_key,
+            base_url=base_url,
+        )

--- a/src/coderpad/screen.py
+++ b/src/coderpad/screen.py
@@ -14,7 +14,7 @@ from coderpad.screen_types import (
     ScreenTestsPage,
     ScreenWebhook,
 )
-from coderpad.transports import Transport, TransportResponse
+from coderpad.transports import JSONTransport, TransportResponse
 
 SCREEN_US_BASE_URL = "https://www.codingame.com"
 SCREEN_EU_BASE_URL = "https://www.codingame.eu"
@@ -28,14 +28,14 @@ class _ScreenNamespace:
     def __init__(
         self,
         *,
-        transport: Transport,
+        transport: JSONTransport,
         api_key: str,
         base_url: str,
     ) -> None:
         """Create shared Screen request state."""
-        self.transport = transport
-        self.base_url = base_url.rstrip("/")
-        self.headers = {"API-Key": api_key}
+        self.transport: JSONTransport = transport
+        self.base_url: str = base_url.rstrip("/")
+        self.headers: dict[str, str] = {"API-Key": api_key}
 
     def _request(
         self,
@@ -65,11 +65,8 @@ class ScreenCampaignsNamespace(_ScreenNamespace):
     def list(self) -> builtins.list[ScreenCampaign]:
         """List assessment campaigns."""
         response = self._request(method="GET", path="/campaigns")
-        return [
-            ScreenCampaign.from_dict(data=item)
-            for item in response.json()
-            if isinstance(item, dict)
-        ]
+        raw_campaigns: object = response.json()
+        return ScreenCampaign.list_from_value(value=raw_campaigns)
 
     def send_invitation(
         self,
@@ -135,7 +132,9 @@ class ScreenTestsNamespace(_ScreenNamespace):
         with_community_stats: bool = False,
     ) -> ScreenTest:
         """Retrieve one test session."""
-        params = {"withCommunityStats": "true"} if with_community_stats else {}
+        params: dict[str, str | int] = (
+            {"withCommunityStats": "true"} if with_community_stats else {}
+        )
         response = self._request(
             method="GET",
             path=f"/tests/{test_id}",
@@ -209,7 +208,7 @@ class ScreenNamespace(_ScreenNamespace):
     def __init__(
         self,
         *,
-        transport: Transport,
+        transport: JSONTransport,
         api_key: str,
         base_url: str,
     ) -> None:
@@ -219,17 +218,17 @@ class ScreenNamespace(_ScreenNamespace):
             api_key=api_key,
             base_url=base_url,
         )
-        self.campaigns = ScreenCampaignsNamespace(
+        self.campaigns: ScreenCampaignsNamespace = ScreenCampaignsNamespace(
             transport=transport,
             api_key=api_key,
             base_url=base_url,
         )
-        self.tests = ScreenTestsNamespace(
+        self.tests: ScreenTestsNamespace = ScreenTestsNamespace(
             transport=transport,
             api_key=api_key,
             base_url=base_url,
         )
-        self.webhook = ScreenWebhookNamespace(
+        self.webhook: ScreenWebhookNamespace = ScreenWebhookNamespace(
             transport=transport,
             api_key=api_key,
             base_url=base_url,

--- a/src/coderpad/screen_types.py
+++ b/src/coderpad/screen_types.py
@@ -1,0 +1,335 @@
+"""Types for the CoderPad Screen API."""
+
+from dataclasses import dataclass, field
+from typing import Self
+
+from beartype import beartype
+
+
+def _strings(value: object, /) -> list[str]:
+    """Return a string list from an API value."""
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str)]
+
+
+def _optional_int(value: object, /) -> int | None:
+    """Return an integer API value when present."""
+    return (
+        value
+        if isinstance(value, int) and not isinstance(value, bool)
+        else None
+    )
+
+
+def _optional_float(value: object, /) -> float | None:
+    """Return a numeric API value when present."""
+    return float(value) if isinstance(value, int | float) else None
+
+
+def _optional_str(value: object, /) -> str | None:
+    """Return a string API value when present."""
+    return value if isinstance(value, str) else None
+
+
+@beartype
+@dataclass(frozen=True, kw_only=True)
+class ScreenCampaign:
+    """A reusable Screen assessment campaign."""
+
+    id: int
+    name: str
+    languages: list[str] = field(default_factory=list)
+    pinned: bool = False
+    archived: bool = False
+
+    @classmethod
+    def from_dict(cls, data: dict[str, object]) -> Self:
+        """Create a campaign from an API response."""
+        return cls(
+            id=int(data["id"]),
+            name=f"{data['name']}",
+            languages=_strings(data.get("languages")),
+            pinned=data.get("pinned") is True,
+            archived=data.get("archived") is True,
+        )
+
+
+@beartype
+@dataclass(frozen=True, kw_only=True)
+class ScreenInvitation:
+    """An invitation to a Screen campaign."""
+
+    candidate_email: str | None = None
+    candidate_name: str | None = None
+    recruiter_email: str | None = None
+    tags: str | None = None
+    send_invitation_email: bool | None = None
+    send_notification_email_on_bounce: bool | None = None
+
+    def to_dict(self) -> dict[str, str | bool]:
+        """Create the JSON request body, omitting unset fields."""
+        values: dict[str, str | bool | None] = {
+            "candidate_email": self.candidate_email,
+            "candidate_name": self.candidate_name,
+            "recruiter_email": self.recruiter_email,
+            "tags": self.tags,
+            "send_invitation_email": self.send_invitation_email,
+            "send_notification_email_on_bounce": (
+                self.send_notification_email_on_bounce
+            ),
+        }
+        return {
+            key: value for key, value in values.items() if value is not None
+        }
+
+
+@beartype
+@dataclass(frozen=True, kw_only=True)
+class ScreenInvitationResult:
+    """The result of creating a Screen test invitation."""
+
+    id: int | None
+    test_url: str | None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, object]) -> Self:
+        """Create an invitation result from an API response."""
+        return cls(
+            id=_optional_int(data.get("id")),
+            test_url=_optional_str(data.get("test_url")),
+        )
+
+
+@beartype
+@dataclass(frozen=True, kw_only=True)
+class ScreenTestQuestion:
+    """A question included in a Screen test."""
+
+    id: int
+    last_activity_time: int | None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, object]) -> Self:
+        """Create a question from an API response."""
+        return cls(
+            id=int(data["id"]),
+            last_activity_time=_optional_int(data.get("last_activity_time")),
+        )
+
+
+@beartype
+@dataclass(frozen=True, kw_only=True)
+class ScreenSkillResult:
+    """A scored skill within a Screen report."""
+
+    points: int | None
+    score: float | None
+    total_points: int | None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, object]) -> Self:
+        """Create a skill result from an API response."""
+        return cls(
+            points=_optional_int(data.get("points")),
+            score=_optional_float(data.get("score")),
+            total_points=_optional_int(data.get("total_points")),
+        )
+
+
+@beartype
+@dataclass(frozen=True, kw_only=True)
+class ScreenTechnologyResult:
+    """A scored technology within a Screen report."""
+
+    points: int | None
+    score: float | None
+    skills: dict[str, ScreenSkillResult]
+    total_points: int | None
+    comparative_score: float | None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, object]) -> Self:
+        """Create a technology result from an API response."""
+        raw_skills = data.get("skills")
+        skills = (
+            {
+                name: ScreenSkillResult.from_dict(data=value)
+                for name, value in raw_skills.items()
+                if isinstance(name, str) and isinstance(value, dict)
+            }
+            if isinstance(raw_skills, dict)
+            else {}
+        )
+        return cls(
+            points=_optional_int(data.get("points")),
+            score=_optional_float(data.get("score")),
+            skills=skills,
+            total_points=_optional_int(data.get("total_points")),
+            comparative_score=_optional_float(data.get("comparative_score")),
+        )
+
+
+@beartype
+@dataclass(frozen=True, kw_only=True)
+class ScreenReport:
+    """A candidate's scored Screen report."""
+
+    duration: int | None
+    warnings: list[str]
+    points: int | None
+    score: float | None
+    technologies: dict[str, ScreenTechnologyResult]
+    total_duration: int | None
+    total_points: int | None
+    comparative_score: float | None
+    community_stats: list[int] | None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, object]) -> Self:
+        """Create a report from an API response."""
+        raw_technologies = data.get("technologies")
+        technologies = (
+            {
+                name: ScreenTechnologyResult.from_dict(data=value)
+                for name, value in raw_technologies.items()
+                if isinstance(name, str) and isinstance(value, dict)
+            }
+            if isinstance(raw_technologies, dict)
+            else {}
+        )
+        raw_community_stats = data.get("community_stats")
+        community_stats = (
+            [
+                item
+                for item in raw_community_stats
+                if isinstance(item, int) and not isinstance(item, bool)
+            ]
+            if isinstance(raw_community_stats, list)
+            else None
+        )
+        return cls(
+            duration=_optional_int(data.get("duration")),
+            warnings=_strings(data.get("warnings")),
+            points=_optional_int(data.get("points")),
+            score=_optional_float(data.get("score")),
+            technologies=technologies,
+            total_duration=_optional_int(data.get("total_duration")),
+            total_points=_optional_int(data.get("total_points")),
+            comparative_score=_optional_float(data.get("comparative_score")),
+            community_stats=community_stats,
+        )
+
+
+@beartype
+@dataclass(frozen=True, kw_only=True)
+class ScreenTest:
+    """A candidate's Screen test session."""
+
+    id: int
+    status: str
+    campaign_id: int | None
+    candidate_name: str | None
+    candidate_email: str | None
+    tags: list[str]
+    send_time: int | None
+    start_time: int | None
+    end_time: int | None
+    last_activity_time: int | None
+    url: str | None
+    test_url: str | None
+    report: ScreenReport | None
+    questions: list[ScreenTestQuestion]
+
+    @classmethod
+    def from_dict(cls, data: dict[str, object]) -> Self:
+        """Create a test session from an API response."""
+        raw_report = data.get("report")
+        raw_questions = data.get("questions")
+        return cls(
+            id=int(data["id"]),
+            status=f"{data.get('status', 'unknown')}",
+            campaign_id=_optional_int(data.get("campaign_id")),
+            candidate_name=_optional_str(data.get("candidate_name")),
+            candidate_email=_optional_str(data.get("candidate_email")),
+            tags=_strings(data.get("tags")),
+            send_time=_optional_int(data.get("send_time")),
+            start_time=_optional_int(data.get("start_time")),
+            end_time=_optional_int(data.get("end_time")),
+            last_activity_time=_optional_int(data.get("last_activity_time")),
+            url=_optional_str(data.get("url")),
+            test_url=_optional_str(data.get("test_url")),
+            report=ScreenReport.from_dict(data=raw_report)
+            if isinstance(raw_report, dict)
+            else None,
+            questions=[
+                ScreenTestQuestion.from_dict(data=item)
+                for item in raw_questions
+                if isinstance(item, dict)
+            ]
+            if isinstance(raw_questions, list)
+            else [],
+        )
+
+
+@beartype
+@dataclass(frozen=True, kw_only=True)
+class ScreenPagination:
+    """Offset pagination metadata returned by Screen."""
+
+    start: int | None
+    limit: int | None
+    total: int | None
+    has_more_items: bool
+    next_start: int | None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, object]) -> Self:
+        """Create pagination metadata from an API response."""
+        return cls(
+            start=_optional_int(data.get("start")),
+            limit=_optional_int(data.get("limit")),
+            total=_optional_int(data.get("total")),
+            has_more_items=data.get("has_more_items") is True,
+            next_start=_optional_int(data.get("next_start")),
+        )
+
+
+@beartype
+@dataclass(frozen=True, kw_only=True)
+class ScreenTestsPage:
+    """One page of Screen test sessions."""
+
+    tests: list[ScreenTest]
+    pagination: ScreenPagination | None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, object]) -> Self:
+        """Create a tests page from an API response."""
+        raw_tests = data.get("tests")
+        raw_pagination = data.get("pagination")
+        return cls(
+            tests=[
+                ScreenTest.from_dict(data=item)
+                for item in raw_tests
+                if isinstance(item, dict)
+            ]
+            if isinstance(raw_tests, list)
+            else [],
+            pagination=ScreenPagination.from_dict(data=raw_pagination)
+            if isinstance(raw_pagination, dict)
+            else None,
+        )
+
+
+@beartype
+@dataclass(frozen=True, kw_only=True)
+class ScreenWebhook:
+    """The configured Screen webhook."""
+
+    url: str | None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, object]) -> Self:
+        """Create webhook configuration from an API response."""
+        return cls(url=_optional_str(data.get("url")))

--- a/src/coderpad/screen_types.py
+++ b/src/coderpad/screen_types.py
@@ -1,16 +1,44 @@
 """Types for the CoderPad Screen API."""
 
 from dataclasses import dataclass, field
-from typing import Self
+from typing import Self, TypeGuard
 
 from beartype import beartype
 
 
+def _is_object_list(value: object, /) -> TypeGuard[list[object]]:
+    """Return whether an API value is a list."""
+    return isinstance(value, list)
+
+
+def _is_object_mapping(
+    value: object,
+    /,
+) -> TypeGuard[dict[object, object]]:
+    """Return whether an API value is a mapping."""
+    return isinstance(value, dict)
+
+
+def _objects(value: object, /) -> list[object]:
+    """Return an object list from an API value."""
+    return value if _is_object_list(value) else []
+
+
+def _mapping(value: object, /) -> dict[str, object] | None:
+    """Return a string-keyed mapping from an API value."""
+    if not _is_object_mapping(value):
+        return None
+    return {key: item for key, item in value.items() if isinstance(key, str)}
+
+
 def _strings(value: object, /) -> list[str]:
     """Return a string list from an API value."""
-    if not isinstance(value, list):
-        return []
-    return [item for item in value if isinstance(item, str)]
+    return [item for item in _objects(value) if isinstance(item, str)]
+
+
+def _empty_strings() -> list[str]:
+    """Create an empty string list."""
+    return []
 
 
 def _optional_int(value: object, /) -> int | None:
@@ -20,6 +48,14 @@ def _optional_int(value: object, /) -> int | None:
         if isinstance(value, int) and not isinstance(value, bool)
         else None
     )
+
+
+def _required_int(value: object, /) -> int:
+    """Return a required integer API value."""
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value
+    msg = "Expected an integer API value"
+    raise TypeError(msg)
 
 
 def _optional_float(value: object, /) -> float | None:
@@ -39,15 +75,24 @@ class ScreenCampaign:
 
     id: int
     name: str
-    languages: list[str] = field(default_factory=list)
+    languages: list[str] = field(default_factory=_empty_strings)
     pinned: bool = False
     archived: bool = False
+
+    @classmethod
+    def list_from_value(cls, value: object) -> list[Self]:
+        """Create campaigns from an API response value."""
+        return [
+            cls.from_dict(data=mapping)
+            for item in _objects(value)
+            if (mapping := _mapping(item)) is not None
+        ]
 
     @classmethod
     def from_dict(cls, data: dict[str, object]) -> Self:
         """Create a campaign from an API response."""
         return cls(
-            id=int(data["id"]),
+            id=_required_int(data["id"]),
             name=f"{data['name']}",
             languages=_strings(data.get("languages")),
             pinned=data.get("pinned") is True,
@@ -113,7 +158,7 @@ class ScreenTestQuestion:
     def from_dict(cls, data: dict[str, object]) -> Self:
         """Create a question from an API response."""
         return cls(
-            id=int(data["id"]),
+            id=_required_int(data["id"]),
             last_activity_time=_optional_int(data.get("last_activity_time")),
         )
 
@@ -151,14 +196,14 @@ class ScreenTechnologyResult:
     @classmethod
     def from_dict(cls, data: dict[str, object]) -> Self:
         """Create a technology result from an API response."""
-        raw_skills = data.get("skills")
+        typed_skills = _mapping(data.get("skills"))
         skills = (
             {
-                name: ScreenSkillResult.from_dict(data=value)
-                for name, value in raw_skills.items()
-                if isinstance(name, str) and isinstance(value, dict)
+                name: ScreenSkillResult.from_dict(data=mapped)
+                for name, raw_value in typed_skills.items()
+                if (mapped := _mapping(raw_value)) is not None
             }
-            if isinstance(raw_skills, dict)
+            if typed_skills is not None
             else {}
         )
         return cls(
@@ -188,21 +233,22 @@ class ScreenReport:
     @classmethod
     def from_dict(cls, data: dict[str, object]) -> Self:
         """Create a report from an API response."""
-        raw_technologies = data.get("technologies")
+        typed_technologies = _mapping(data.get("technologies"))
         technologies = (
             {
-                name: ScreenTechnologyResult.from_dict(data=value)
-                for name, value in raw_technologies.items()
-                if isinstance(name, str) and isinstance(value, dict)
+                name: ScreenTechnologyResult.from_dict(data=mapped)
+                for name, raw_value in typed_technologies.items()
+                if (mapped := _mapping(raw_value)) is not None
             }
-            if isinstance(raw_technologies, dict)
+            if typed_technologies is not None
             else {}
         )
-        raw_community_stats = data.get("community_stats")
+        raw_community_stats: object = data.get("community_stats")
+        community_items = _objects(raw_community_stats)
         community_stats = (
             [
                 item
-                for item in raw_community_stats
+                for item in community_items
                 if isinstance(item, int) and not isinstance(item, bool)
             ]
             if isinstance(raw_community_stats, list)
@@ -244,10 +290,10 @@ class ScreenTest:
     @classmethod
     def from_dict(cls, data: dict[str, object]) -> Self:
         """Create a test session from an API response."""
-        raw_report = data.get("report")
-        raw_questions = data.get("questions")
+        raw_report = _mapping(data.get("report"))
+        typed_questions = _objects(data.get("questions"))
         return cls(
-            id=int(data["id"]),
+            id=_required_int(data["id"]),
             status=f"{data.get('status', 'unknown')}",
             campaign_id=_optional_int(data.get("campaign_id")),
             candidate_name=_optional_str(data.get("candidate_name")),
@@ -260,15 +306,13 @@ class ScreenTest:
             url=_optional_str(data.get("url")),
             test_url=_optional_str(data.get("test_url")),
             report=ScreenReport.from_dict(data=raw_report)
-            if isinstance(raw_report, dict)
+            if raw_report is not None
             else None,
             questions=[
-                ScreenTestQuestion.from_dict(data=item)
-                for item in raw_questions
-                if isinstance(item, dict)
-            ]
-            if isinstance(raw_questions, list)
-            else [],
+                ScreenTestQuestion.from_dict(data=mapping)
+                for item in typed_questions
+                if (mapping := _mapping(item)) is not None
+            ],
         )
 
 
@@ -306,18 +350,16 @@ class ScreenTestsPage:
     @classmethod
     def from_dict(cls, data: dict[str, object]) -> Self:
         """Create a tests page from an API response."""
-        raw_tests = data.get("tests")
-        raw_pagination = data.get("pagination")
+        typed_tests = _objects(data.get("tests"))
+        raw_pagination = _mapping(data.get("pagination"))
         return cls(
             tests=[
-                ScreenTest.from_dict(data=item)
-                for item in raw_tests
-                if isinstance(item, dict)
-            ]
-            if isinstance(raw_tests, list)
-            else [],
+                ScreenTest.from_dict(data=mapping)
+                for item in typed_tests
+                if (mapping := _mapping(item)) is not None
+            ],
             pagination=ScreenPagination.from_dict(data=raw_pagination)
-            if isinstance(raw_pagination, dict)
+            if raw_pagination is not None
             else None,
         )
 

--- a/src/coderpad/screen_types.py
+++ b/src/coderpad/screen_types.py
@@ -60,7 +60,11 @@ def _required_int(value: object, /) -> int:
 
 def _optional_float(value: object, /) -> float | None:
     """Return a numeric API value when present."""
-    return float(value) if isinstance(value, int | float) else None
+    return (
+        float(value)
+        if isinstance(value, int | float) and not isinstance(value, bool)
+        else None
+    )
 
 
 def _optional_str(value: object, /) -> str | None:
@@ -294,7 +298,7 @@ class ScreenTest:
         typed_questions = _objects(data.get("questions"))
         return cls(
             id=_required_int(data["id"]),
-            status=f"{data.get('status', 'unknown')}",
+            status=_optional_str(data.get("status")) or "unknown",
             campaign_id=_optional_int(data.get("campaign_id")),
             candidate_name=_optional_str(data.get("candidate_name")),
             candidate_email=_optional_str(data.get("candidate_email")),

--- a/src/coderpad/transports.py
+++ b/src/coderpad/transports.py
@@ -77,6 +77,7 @@ class Transport(Protocol):
         params: dict[str, str | int] | None = None,
         data: dict[str, str] | None = None,
         files: (dict[str, tuple[str, bytes, str]] | None) = None,
+        json: object | None = None,
     ) -> TransportResponse:
         """Make an HTTP request.
 
@@ -89,6 +90,7 @@ class Transport(Protocol):
             files: Files to upload as multipart form data.
                 Each key is the field name, and the value is
                 a ``(filename, content, content_type)`` tuple.
+            json: A JSON-compatible request body.
 
         Returns:
             A ``TransportResponse`` populated from the HTTP
@@ -139,6 +141,7 @@ class HTTPXTransport:
         params: dict[str, str | int] | None = None,
         data: dict[str, str] | None = None,
         files: (dict[str, tuple[str, bytes, str]] | None) = None,
+        json: object | None = None,
     ) -> TransportResponse:
         """Make an HTTP request using ``httpx``.
 
@@ -149,6 +152,7 @@ class HTTPXTransport:
             params: Query parameters.
             data: Form data to send in the request body.
             files: Files to upload as multipart form data.
+            json: A JSON-compatible request body.
 
         Returns:
             A ``TransportResponse`` populated from the httpx
@@ -161,6 +165,7 @@ class HTTPXTransport:
             params=params,
             data=data,
             files=files,
+            json=json,
         )
         return TransportResponse(
             status_code=response.status_code,
@@ -186,6 +191,7 @@ class AsyncTransport(Protocol):
         params: dict[str, str | int] | None = None,
         data: dict[str, str] | None = None,
         files: (dict[str, tuple[str, bytes, str]] | None) = None,
+        json: object | None = None,
     ) -> TransportResponse:
         """Make an async HTTP request.
 
@@ -198,6 +204,7 @@ class AsyncTransport(Protocol):
             files: Files to upload as multipart form data.
                 Each key is the field name, and the value is
                 a ``(filename, content, content_type)`` tuple.
+            json: A JSON-compatible request body.
 
         Returns:
             A ``TransportResponse`` populated from the HTTP
@@ -249,6 +256,7 @@ class AsyncHTTPXTransport:
         params: dict[str, str | int] | None = None,
         data: dict[str, str] | None = None,
         files: (dict[str, tuple[str, bytes, str]] | None) = None,
+        json: object | None = None,
     ) -> TransportResponse:
         """Make an async HTTP request using ``httpx``.
 
@@ -259,6 +267,7 @@ class AsyncHTTPXTransport:
             params: Query parameters.
             data: Form data to send in the request body.
             files: Files to upload as multipart form data.
+            json: A JSON-compatible request body.
 
         Returns:
             A ``TransportResponse`` populated from the httpx
@@ -271,6 +280,7 @@ class AsyncHTTPXTransport:
             params=params,
             data=data,
             files=files,
+            json=json,
         )
         return TransportResponse(
             status_code=response.status_code,

--- a/src/coderpad/transports.py
+++ b/src/coderpad/transports.py
@@ -77,7 +77,6 @@ class Transport(Protocol):
         params: dict[str, str | int] | None = None,
         data: dict[str, str] | None = None,
         files: (dict[str, tuple[str, bytes, str]] | None) = None,
-        json: object | None = None,
     ) -> TransportResponse:
         """Make an HTTP request.
 
@@ -90,12 +89,30 @@ class Transport(Protocol):
             files: Files to upload as multipart form data.
                 Each key is the field name, and the value is
                 a ``(filename, content, content_type)`` tuple.
-            json: A JSON-compatible request body.
 
         Returns:
             A ``TransportResponse`` populated from the HTTP
             response.
         """
+        ...  # pylint: disable=unnecessary-ellipsis
+
+
+@runtime_checkable
+class JSONTransport(Protocol):
+    """Protocol for transports supporting JSON request bodies."""
+
+    def __call__(
+        self,
+        *,
+        method: str,
+        url: str,
+        headers: dict[str, str],
+        params: dict[str, str | int] | None = None,
+        data: dict[str, str] | None = None,
+        files: (dict[str, tuple[str, bytes, str]] | None) = None,
+        json: object | None = None,
+    ) -> TransportResponse:
+        """Make an HTTP request with an optional JSON body."""
         ...  # pylint: disable=unnecessary-ellipsis
 
 
@@ -191,7 +208,6 @@ class AsyncTransport(Protocol):
         params: dict[str, str | int] | None = None,
         data: dict[str, str] | None = None,
         files: (dict[str, tuple[str, bytes, str]] | None) = None,
-        json: object | None = None,
     ) -> TransportResponse:
         """Make an async HTTP request.
 
@@ -204,12 +220,30 @@ class AsyncTransport(Protocol):
             files: Files to upload as multipart form data.
                 Each key is the field name, and the value is
                 a ``(filename, content, content_type)`` tuple.
-            json: A JSON-compatible request body.
 
         Returns:
             A ``TransportResponse`` populated from the HTTP
             response.
         """
+        ...  # pylint: disable=unnecessary-ellipsis
+
+
+@runtime_checkable
+class AsyncJSONTransport(Protocol):
+    """Protocol for async transports supporting JSON request bodies."""
+
+    async def __call__(
+        self,
+        *,
+        method: str,
+        url: str,
+        headers: dict[str, str],
+        params: dict[str, str | int] | None = None,
+        data: dict[str, str] | None = None,
+        files: (dict[str, tuple[str, bytes, str]] | None) = None,
+        json: object | None = None,
+    ) -> TransportResponse:
+        """Make an async HTTP request with an optional JSON body."""
         ...  # pylint: disable=unnecessary-ellipsis
 
 

--- a/tests/test_async_screen.py
+++ b/tests/test_async_screen.py
@@ -1,6 +1,9 @@
 """Tests for asynchronous CoderPad Screen support."""
 
-# ruff: noqa: PLR2004
+# ruff: noqa: PLR0911, PLR2004
+
+import json as json_module
+from http import HTTPStatus
 
 import pytest
 
@@ -9,15 +12,14 @@ from coderpad.exceptions import AuthenticationError
 from coderpad.screen_types import ScreenInvitation
 from coderpad.transports import TransportResponse
 
-from .test_screen import _ScreenTransport
-
 
 class _AsyncScreenTransport:
-    """Asynchronously adapt the shared recording transport."""
+    """Record asynchronous Screen requests."""
 
-    def __init__(self, sync: _ScreenTransport) -> None:
-        """Create an asynchronous transport adapter."""
-        self.sync = sync
+    def __init__(self, *, error: bool = False) -> None:
+        """Create a recording transport."""
+        self.calls: list[dict[str, object]] = []
+        self.error = error
 
     async def __call__(
         self,
@@ -30,16 +32,74 @@ class _AsyncScreenTransport:
         files: dict[str, tuple[str, bytes, str]] | None = None,
         json: object | None = None,
     ) -> TransportResponse:
-        """Forward to the synchronous recording transport."""
-        return self.sync(
-            method=method,
-            url=url,
-            headers=headers,
-            params=params,
-            data=data,
-            files=files,
-            json=json,
+        """Return a response selected by the request path."""
+        del data, files
+        self.calls.append(
+            {
+                "method": method,
+                "url": url,
+                "headers": headers,
+                "params": params or {},
+                "json": json,
+            },
         )
+        if self.error:
+            return _response(
+                {"code": "Unauthorized", "message": "Invalid API key"},
+                status=HTTPStatus.UNAUTHORIZED,
+            )
+        if url.endswith("/campaigns"):
+            return _response([{"id": 7, "name": "Backend"}])
+        if url.endswith("/campaigns/7/actions/send"):
+            return _response({"id": 11, "test_url": "https://test.example"})
+        if url.endswith("/tests"):
+            return _response(
+                {
+                    "tests": [
+                        {
+                            "id": 11,
+                            "status": "completed",
+                            "report": dict[str, object](),
+                        },
+                    ],
+                    "pagination": {"total": 2},
+                },
+            )
+        if url.endswith("/tests/11/report"):
+            return TransportResponse(
+                status_code=HTTPStatus.OK,
+                headers={"content-type": "application/pdf"},
+                content=b"%PDF report",
+            )
+        if url.endswith("/tests/11"):
+            return _response(
+                {
+                    "id": 11,
+                    "status": "completed",
+                    "report": dict[str, object](),
+                },
+            )
+        if url.endswith("/webhook") and method == "GET":
+            return _response({"url": "https://example.com/hook"})
+        return TransportResponse(
+            status_code=HTTPStatus.NO_CONTENT,
+            headers={},
+            content=b"",
+        )
+
+
+def _response(
+    value: object,
+    /,
+    *,
+    status: HTTPStatus = HTTPStatus.OK,
+) -> TransportResponse:
+    """Create a JSON transport response."""
+    return TransportResponse(
+        status_code=status,
+        headers={"content-type": "application/json"},
+        content=json_module.dumps(obj=value).encode(),
+    )
 
 
 def _client(transport: _AsyncScreenTransport, /) -> AsyncCoderPad:
@@ -47,15 +107,16 @@ def _client(transport: _AsyncScreenTransport, /) -> AsyncCoderPad:
     return AsyncCoderPad(
         api_key="interview-key",
         screen_api_key="screen-key",
-        transport=transport,
+        screen_transport=transport,
     )
 
 
 @pytest.mark.asyncio
 async def test_async_screen_matches_sync_surface() -> None:
     """The asynchronous namespaces expose equivalent operations."""
-    recorder = _ScreenTransport()
-    screen = _client(_AsyncScreenTransport(sync=recorder)).screen
+    recorder = _AsyncScreenTransport()
+    client = _client(recorder)
+    screen = client.screen
     campaigns = await screen.campaigns.list()
     invitation = await screen.campaigns.send_invitation(
         campaign_id=7,
@@ -87,12 +148,13 @@ async def test_async_screen_matches_sync_surface() -> None:
         "include_rank": "false",
     }
     assert webhook.url == "https://example.com/hook"
+    await client.aclose()
 
 
 @pytest.mark.asyncio
 async def test_async_screen_errors_use_existing_hierarchy() -> None:
     """Async Screen failures map to the shared exception hierarchy."""
-    recorder = _ScreenTransport(error=True)
-    screen = _client(_AsyncScreenTransport(sync=recorder)).screen
+    recorder = _AsyncScreenTransport(error=True)
+    screen = _client(recorder).screen
     with pytest.raises(expected_exception=AuthenticationError):
         await screen.campaigns.list()

--- a/tests/test_async_screen.py
+++ b/tests/test_async_screen.py
@@ -1,0 +1,78 @@
+"""Tests for asynchronous CoderPad Screen support."""
+
+# ruff: noqa: PLR2004
+
+import pytest
+
+from coderpad import AsyncCoderPad
+from coderpad.screen_types import ScreenInvitation
+from coderpad.transports import TransportResponse
+
+from .test_screen import _ScreenTransport
+
+
+class _AsyncScreenTransport:
+    """Asynchronously adapt the shared recording transport."""
+
+    def __init__(self, sync: _ScreenTransport) -> None:
+        """Create an asynchronous transport adapter."""
+        self.sync = sync
+
+    async def __call__(
+        self,
+        *,
+        method: str,
+        url: str,
+        headers: dict[str, str],
+        params: dict[str, str | int] | None = None,
+        data: dict[str, str] | None = None,
+        files: dict[str, tuple[str, bytes, str]] | None = None,
+        json: object | None = None,
+    ) -> TransportResponse:
+        """Forward to the synchronous recording transport."""
+        return self.sync(
+            method=method,
+            url=url,
+            headers=headers,
+            params=params,
+            data=data,
+            files=files,
+            json=json,
+        )
+
+
+def _client(transport: _AsyncScreenTransport, /) -> AsyncCoderPad:
+    """Create an asynchronous client using the recording transport."""
+    return AsyncCoderPad(
+        api_key="interview-key",
+        screen_api_key="screen-key",
+        transport=transport,
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_screen_matches_sync_surface() -> None:
+    """The asynchronous namespaces expose equivalent operations."""
+    recorder = _ScreenTransport()
+    screen = _client(_AsyncScreenTransport(sync=recorder)).screen
+    campaigns = await screen.campaigns.list()
+    invitation = await screen.campaigns.send_invitation(
+        campaign_id=7,
+        invitation=ScreenInvitation(candidate_name="Ada"),
+    )
+    page = await screen.tests.list(start=0, limit=1)
+    test = await screen.tests.get(test_id=11, with_community_stats=True)
+    await screen.tests.cancel(test_id=11)
+    await screen.tests.resend(test_id=11)
+    await screen.tests.delete(test_id=11)
+    report = await screen.tests.report(test_id=11)
+    webhook = await screen.webhook.get()
+    await screen.webhook.set(url="https://example.com/hook")
+    await screen.webhook.delete()
+    assert campaigns[0].id == 7
+    assert invitation.id == 11
+    assert page.pagination is not None
+    assert page.pagination.total == 2
+    assert test.report is not None
+    assert report == b"%PDF report"
+    assert webhook.url == "https://example.com/hook"

--- a/tests/test_async_screen.py
+++ b/tests/test_async_screen.py
@@ -5,6 +5,7 @@
 import pytest
 
 from coderpad import AsyncCoderPad
+from coderpad.exceptions import AuthenticationError
 from coderpad.screen_types import ScreenInvitation
 from coderpad.transports import TransportResponse
 
@@ -65,7 +66,12 @@ async def test_async_screen_matches_sync_surface() -> None:
     await screen.tests.cancel(test_id=11)
     await screen.tests.resend(test_id=11)
     await screen.tests.delete(test_id=11)
-    report = await screen.tests.report(test_id=11)
+    report = await screen.tests.report(
+        test_id=11,
+        report_type="full",
+        anonymous=True,
+        include_rank=False,
+    )
     webhook = await screen.webhook.get()
     await screen.webhook.set(url="https://example.com/hook")
     await screen.webhook.delete()
@@ -75,4 +81,18 @@ async def test_async_screen_matches_sync_surface() -> None:
     assert page.pagination.total == 2
     assert test.report is not None
     assert report == b"%PDF report"
+    assert recorder.calls[7]["params"] == {
+        "report_type": "full",
+        "anonymous": "true",
+        "include_rank": "false",
+    }
     assert webhook.url == "https://example.com/hook"
+
+
+@pytest.mark.asyncio
+async def test_async_screen_errors_use_existing_hierarchy() -> None:
+    """Async Screen failures map to the shared exception hierarchy."""
+    recorder = _ScreenTransport(error=True)
+    screen = _client(_AsyncScreenTransport(sync=recorder)).screen
+    with pytest.raises(expected_exception=AuthenticationError):
+        await screen.campaigns.list()

--- a/tests/test_screen.py
+++ b/tests/test_screen.py
@@ -2,7 +2,7 @@
 
 # ruff: noqa: PLR0911, PLR2004
 
-import json
+import json as json_module
 from http import HTTPStatus
 
 import pytest
@@ -127,7 +127,7 @@ def _response(
     return TransportResponse(
         status_code=status,
         headers={"content-type": "application/json"},
-        content=json.dumps(obj=value).encode(),
+        content=json_module.dumps(obj=value).encode(),
     )
 
 

--- a/tests/test_screen.py
+++ b/tests/test_screen.py
@@ -9,7 +9,7 @@ import pytest
 
 from coderpad import SCREEN_EU_BASE_URL, CoderPad
 from coderpad.exceptions import AuthenticationError
-from coderpad.screen_types import ScreenInvitation
+from coderpad.screen_types import ScreenCampaign, ScreenInvitation, ScreenTest
 from coderpad.transports import TransportResponse
 
 _TEST = {
@@ -40,7 +40,7 @@ _TEST = {
 }
 
 
-class _ScreenTransport:
+class ScreenTransportStub:
     """Record requests and return representative Screen responses."""
 
     def __init__(self, *, error: bool = False) -> None:
@@ -132,7 +132,7 @@ def _response(
 
 
 def _client(
-    transport: _ScreenTransport,
+    transport: ScreenTransportStub,
     /,
     *,
     base_url: str = SCREEN_EU_BASE_URL,
@@ -142,13 +142,13 @@ def _client(
         api_key="interview-key",
         screen_api_key="screen-key",
         screen_base_url=base_url,
-        transport=transport,
+        screen_transport=transport,
     )
 
 
 def test_campaigns_and_invitation() -> None:
     """Campaigns and invitations use Screen authentication and JSON."""
-    transport = _ScreenTransport()
+    transport = ScreenTransportStub()
     client = _client(transport)
     campaigns = client.screen.campaigns.list()
     invitation = ScreenInvitation(candidate_email="ada@example.com")
@@ -164,11 +164,20 @@ def test_campaigns_and_invitation() -> None:
     assert transport.calls[0]["headers"] == {"API-Key": "screen-key"}
     assert transport.calls[1]["json"] == {"candidate_email": "ada@example.com"}
     assert f"{transport.calls[0]['url']}".startswith(SCREEN_EU_BASE_URL)
+    client.close()
+
+
+def test_required_integer_fields_are_validated() -> None:
+    """Required integer fields reject malformed API values."""
+    with pytest.raises(expected_exception=TypeError):
+        ScreenCampaign.from_dict(data={"id": "not-an-integer", "name": "Bad"})
+    assert not ScreenCampaign(id=1, name="Empty").languages
+    assert ScreenTest.from_dict(data={"id": 1}).report is None
 
 
 def test_tests_filters_pagination_and_decoding() -> None:
     """Test list filters, pagination, and nested models are preserved."""
-    transport = _ScreenTransport()
+    transport = ScreenTransportStub()
     page = _client(transport).screen.tests.list(
         campaign_id=7,
         status="completed",
@@ -223,7 +232,7 @@ def test_tests_filters_pagination_and_decoding() -> None:
 
 def test_get_actions_report_and_webhook() -> None:
     """Test retrieval, mutations, PDF bytes, and webhook operations."""
-    transport = _ScreenTransport()
+    transport = ScreenTransportStub()
     screen = _client(transport).screen
     test = screen.tests.get(test_id=11, with_community_stats=True)
     screen.tests.cancel(test_id=11)
@@ -247,4 +256,4 @@ def test_get_actions_report_and_webhook() -> None:
 def test_screen_errors_use_existing_hierarchy() -> None:
     """Screen HTTP failures map to the shared exception hierarchy."""
     with pytest.raises(expected_exception=AuthenticationError):
-        _client(_ScreenTransport(error=True)).screen.campaigns.list()
+        _client(ScreenTransportStub(error=True)).screen.campaigns.list()

--- a/tests/test_screen.py
+++ b/tests/test_screen.py
@@ -1,0 +1,250 @@
+"""Tests for synchronous CoderPad Screen support."""
+
+# ruff: noqa: PLR0911, PLR2004
+
+import json
+from http import HTTPStatus
+
+import pytest
+
+from coderpad import SCREEN_EU_BASE_URL, CoderPad
+from coderpad.exceptions import AuthenticationError
+from coderpad.screen_types import ScreenInvitation
+from coderpad.transports import TransportResponse
+
+_TEST = {
+    "id": 11,
+    "status": "completed",
+    "campaign_id": 7,
+    "candidate_name": "Ada",
+    "candidate_email": "ada@example.com",
+    "tags": ["python"],
+    "send_time": 1000,
+    "questions": [{"id": 3, "last_activity_time": 1100}],
+    "report": {
+        "score": 90,
+        "technologies": {
+            "Python": {
+                "score": 95,
+                "skills": {
+                    "Language": {
+                        "points": 9,
+                        "score": 90,
+                        "total_points": 10,
+                    },
+                },
+            },
+        },
+        "community_stats": [1, 2, 3],
+    },
+}
+
+
+class _ScreenTransport:
+    """Record requests and return representative Screen responses."""
+
+    def __init__(self, *, error: bool = False) -> None:
+        """Create a recording transport."""
+        self.calls: list[dict[str, object]] = []
+        self.error = error
+
+    def __call__(
+        self,
+        *,
+        method: str,
+        url: str,
+        headers: dict[str, str],
+        params: dict[str, str | int] | None = None,
+        data: dict[str, str] | None = None,
+        files: dict[str, tuple[str, bytes, str]] | None = None,
+        json: object | None = None,
+    ) -> TransportResponse:
+        """Return a response selected by the request path."""
+        del data, files
+        self.calls.append(
+            {
+                "method": method,
+                "url": url,
+                "headers": headers,
+                "params": params or {},
+                "json": json,
+            },
+        )
+        if self.error:
+            return _response(
+                {"code": "Unauthorized", "message": "Invalid API key"},
+                status=HTTPStatus.UNAUTHORIZED,
+            )
+        if url.endswith("/campaigns"):
+            return _response(
+                [
+                    {
+                        "id": 7,
+                        "name": "Backend",
+                        "languages": ["python"],
+                    },
+                ],
+            )
+        if url.endswith("/campaigns/7/actions/send"):
+            return _response({"id": 11, "test_url": "https://test.example"})
+        if url.endswith("/tests"):
+            return _response(
+                {
+                    "tests": [_TEST],
+                    "pagination": {
+                        "start": 0,
+                        "limit": 1,
+                        "total": 2,
+                        "has_more_items": True,
+                        "next_start": 1,
+                    },
+                },
+            )
+        if url.endswith("/tests/11/report"):
+            return TransportResponse(
+                status_code=HTTPStatus.OK,
+                headers={"content-type": "application/pdf"},
+                content=b"%PDF report",
+            )
+        if url.endswith("/tests/11"):
+            return _response(_TEST)
+        if url.endswith("/webhook") and method == "GET":
+            return _response({"url": "https://example.com/hook"})
+        return TransportResponse(
+            status_code=HTTPStatus.NO_CONTENT,
+            headers={},
+            content=b"",
+        )
+
+
+def _response(
+    value: object,
+    /,
+    *,
+    status: HTTPStatus = HTTPStatus.OK,
+) -> TransportResponse:
+    """Create a JSON transport response."""
+    return TransportResponse(
+        status_code=status,
+        headers={"content-type": "application/json"},
+        content=json.dumps(obj=value).encode(),
+    )
+
+
+def _client(
+    transport: _ScreenTransport,
+    /,
+    *,
+    base_url: str = SCREEN_EU_BASE_URL,
+) -> CoderPad:
+    """Create a client using the recording transport."""
+    return CoderPad(
+        api_key="interview-key",
+        screen_api_key="screen-key",
+        screen_base_url=base_url,
+        transport=transport,
+    )
+
+
+def test_campaigns_and_invitation() -> None:
+    """Campaigns and invitations use Screen authentication and JSON."""
+    transport = _ScreenTransport()
+    client = _client(transport)
+    campaigns = client.screen.campaigns.list()
+    invitation = ScreenInvitation(candidate_email="ada@example.com")
+    result = client.screen.campaigns.send_invitation(
+        campaign_id=campaigns[0].id,
+        invitation=invitation,
+    )
+    assert campaigns[0].languages == ["python"]
+    assert not campaigns[0].pinned
+    assert not campaigns[0].archived
+    assert result.id == 11
+    assert result.test_url == "https://test.example"
+    assert transport.calls[0]["headers"] == {"API-Key": "screen-key"}
+    assert transport.calls[1]["json"] == {"candidate_email": "ada@example.com"}
+    assert f"{transport.calls[0]['url']}".startswith(SCREEN_EU_BASE_URL)
+
+
+def test_tests_filters_pagination_and_decoding() -> None:
+    """Test list filters, pagination, and nested models are preserved."""
+    transport = _ScreenTransport()
+    page = _client(transport).screen.tests.list(
+        campaign_id=7,
+        status="completed",
+        tag="python",
+        search="Ada",
+        product="screen",
+        candidate_email="ada@example.com",
+        from_time=100,
+        to_time=200,
+        start=0,
+        limit=1,
+    )
+    assert page.pagination is not None
+    assert page.pagination.next_start == 1
+    assert page.pagination.has_more_items
+    assert page.tests[0].send_time == 1000
+    assert page.tests[0].last_activity_time is None
+    assert page.tests[0].test_url is None
+    assert page.tests[0].questions[0].last_activity_time == 1100
+    assert page.tests[0].report is not None
+    screen_report = page.tests[0].report
+    assert screen_report.duration is None
+    assert not screen_report.warnings
+    assert screen_report.points is None
+    assert screen_report.score == 90
+    assert screen_report.total_duration is None
+    assert screen_report.total_points is None
+    assert screen_report.comparative_score is None
+    assert screen_report.community_stats == [1, 2, 3]
+    technology = screen_report.technologies["Python"]
+    assert technology.points is None
+    assert technology.score == 95
+    assert technology.total_points is None
+    assert technology.comparative_score is None
+    skill = technology.skills["Language"]
+    assert skill.points == 9
+    assert skill.score == 90
+    assert skill.total_points == 10
+    assert transport.calls[-1]["params"] == {
+        "campaignId": 7,
+        "status": "completed",
+        "tag": "python",
+        "search": "Ada",
+        "product": "screen",
+        "candidateEmail": "ada@example.com",
+        "from": 100,
+        "to": 200,
+        "start": 0,
+        "limit": 1,
+    }
+
+
+def test_get_actions_report_and_webhook() -> None:
+    """Test retrieval, mutations, PDF bytes, and webhook operations."""
+    transport = _ScreenTransport()
+    screen = _client(transport).screen
+    test = screen.tests.get(test_id=11, with_community_stats=True)
+    screen.tests.cancel(test_id=11)
+    screen.tests.resend(test_id=11)
+    screen.tests.delete(test_id=11)
+    report = screen.tests.report(
+        test_id=11,
+        report_type="simplified",
+        anonymous=True,
+    )
+    webhook = screen.webhook.get()
+    screen.webhook.set(url="https://example.com/new-hook")
+    screen.webhook.delete()
+    assert test.candidate_name == "Ada"
+    assert transport.calls[0]["params"] == {"withCommunityStats": "true"}
+    assert report == b"%PDF report"
+    assert webhook.url == "https://example.com/hook"
+    assert transport.calls[-2]["json"] == "https://example.com/new-hook"
+
+
+def test_screen_errors_use_existing_hierarchy() -> None:
+    """Screen HTTP failures map to the shared exception hierarchy."""
+    with pytest.raises(expected_exception=AuthenticationError):
+        _client(_ScreenTransport(error=True)).screen.campaigns.list()

--- a/tests/test_screen.py
+++ b/tests/test_screen.py
@@ -9,7 +9,12 @@ import pytest
 
 from coderpad import SCREEN_EU_BASE_URL, CoderPad
 from coderpad.exceptions import AuthenticationError
-from coderpad.screen_types import ScreenCampaign, ScreenInvitation, ScreenTest
+from coderpad.screen_types import (
+    ScreenCampaign,
+    ScreenInvitation,
+    ScreenReport,
+    ScreenTest,
+)
 from coderpad.transports import TransportResponse
 
 _TEST = {
@@ -173,6 +178,13 @@ def test_required_integer_fields_are_validated() -> None:
         ScreenCampaign.from_dict(data={"id": "not-an-integer", "name": "Bad"})
     assert not ScreenCampaign(id=1, name="Empty").languages
     assert ScreenTest.from_dict(data={"id": 1}).report is None
+
+
+def test_malformed_optional_values_use_defaults() -> None:
+    """Malformed optional API values do not leak into typed models."""
+    assert ScreenReport.from_dict(data={"score": True}).score is None
+    test = ScreenTest.from_dict(data={"id": 1, "status": None})
+    assert test.status == "unknown"
 
 
 def test_tests_filters_pagination_and_decoding() -> None:


### PR DESCRIPTION
## Summary

- add independent CoderPad Screen authentication and US, EU, or custom base URLs
- expose matching sync and async campaign, invitation, test, report, and webhook operations
- add typed models for campaigns, invitations, nested reports, community statistics, and offset pagination
- support campaign, status, tag, search, product, candidate email, date, and pagination filters
- return report bytes without implicit filesystem writes
- export the public Screen models and document pagination and regional configuration

## Impact

Python users can now work with the CoderPad Screen API through the same client
package as Interview while keeping Screen credentials, hosts, and authentication
separate.

## Validation

- `uv run --extra dev pytest -q` (166 passed)
- `uv run --extra dev prek run --all-files`

Closes #227

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large additive integration with a second API host and credentials, but Interview behavior is unchanged and Screen is isolated behind new namespaces with dedicated tests.
> 
> **Overview**
> Adds **typed CoderPad Screen** support alongside Interview via `client.screen` on `CoderPad` and `AsyncCoderPad`, using a **separate API key**, **US/EU base URLs** (`SCREEN_US_BASE_URL`, `SCREEN_EU_BASE_URL`), and optional dedicated transports that are closed with the main client.
> 
> New sync/async namespaces cover **campaigns** (list, send invitations), **tests** (filtered offset-paginated list, get, cancel/resend/delete, report as **bytes**), and **webhooks**. **`screen_types`** models campaigns, invitations, nested reports, pagination, and related fields with defensive parsing.
> 
> **Transports** gain optional `json` bodies via `JSONTransport` / `AsyncJSONTransport`. Public exports, README, API reference, Sybil mocks, and tests document and exercise the new surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a0bc1adbd9b42c6e7eff89a59c7046e25b976fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->