### PR TITLE
Adopt Pydantic models

### DIFF
--- a/docs/source/api-reference.rst
+++ b/docs/source/api-reference.rst
@@ -20,6 +20,7 @@ API Reference
 .. automodule:: coderpad.screen_types
    :undoc-members:
    :members:
+   :exclude-members: __init__, model_config
 
 .. automodule:: coderpad.transports
    :undoc-members:
@@ -28,3 +29,4 @@ API Reference
 .. automodule:: coderpad.types
    :undoc-members:
    :members:
+   :exclude-members: __init__, model_config

--- a/newsfragments/241.change
+++ b/newsfragments/241.change
@@ -1,4 +1,4 @@
 API resource types are now strict, frozen Pydantic v2 models.  Responses are
 validated with ``model_validate`` and request models support
-``model_dump``.  Pydantic replaces beartype as the runtime validation
-dependency.
+``model_dump``.  Beartype continues to provide runtime type checking
+alongside Pydantic.

--- a/newsfragments/241.change
+++ b/newsfragments/241.change
@@ -1,0 +1,4 @@
+API resource types are now strict, frozen Pydantic v2 models.  Responses are
+validated with ``model_validate`` and request models support
+``model_dump``.  Pydantic replaces beartype as the runtime validation
+dependency.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -313,6 +313,8 @@ ignore_names = [
     "__aexit__",
     # pytest fixtures - we name fixtures like this for this purpose
     "_fixture_*",
+    # Pydantic invokes field validators declaratively.
+    "_none_is_not_visible",
     # Language enum members (public API)
     "ANGULAR",
     # Sphinx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,11 +33,13 @@ dynamic = [
     "version",
 ]
 dependencies = [
+    "beartype>=0.22.9",
     "httpx>=0.28.0",
     "pydantic>=2.12.0",
 ]
 optional-dependencies.dev = [
     "actionlint-py==1.7.12.24",
+    "beartype==0.22.9",
     "check-manifest==0.51",
     "deptry==0.25.1",
     "doc8==2.0.0",
@@ -59,6 +61,7 @@ optional-dependencies.dev = [
     "pyroma==5.0.1",
     "pytest==9.1.1",
     "pytest-asyncio==1.4.0",
+    "pytest-beartype-tests==2026.4.26",
     "pytest-cov==7.1.0",
     "pyyaml==6.0.3",
     "respx==0.23.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,12 +33,11 @@ dynamic = [
     "version",
 ]
 dependencies = [
-    "beartype>=0.22.9",
     "httpx>=0.28.0",
+    "pydantic>=2.12.0",
 ]
 optional-dependencies.dev = [
     "actionlint-py==1.7.12.24",
-    "beartype==0.22.9",
     "check-manifest==0.51",
     "deptry==0.25.1",
     "doc8==2.0.0",
@@ -60,7 +59,6 @@ optional-dependencies.dev = [
     "pyroma==5.0.1",
     "pytest==9.1.1",
     "pytest-asyncio==1.4.0",
-    "pytest-beartype-tests==2026.4.26",
     "pytest-cov==7.1.0",
     "pyyaml==6.0.3",
     "respx==0.23.1",
@@ -359,6 +357,8 @@ ignore_names = [
     "LUA",
     "MARKDOWN",
     "master_doc",
+    # Pydantic consumes this declarative class configuration.
+    "model_config",
     "MULTIFILE_*",
     "MYSQL",
     "NEXTJS",
@@ -383,16 +383,21 @@ ignore_names = [
     "RAILS",
     "REACT",
     "REACT_NATIVE_WEB",
+    # Public Pydantic fields are consumed through model serialization.
+    "recruiter_email",
     "rst_prolog",
     "RUBY",
     "RUST",
     "SCALA",
+    "send_invitation_email",
+    "send_notification_email_on_bounce",
     "SOLIDITY",
     "source_suffix",
     "spelling_word_list_filename",
     "SPRING",
     "SVELTE",
     "SWIFT",
+    "tags",
     "TCL",
     "templates_path",
     "towncrier_draft_autoversion_mode",

--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -1,5 +1,7 @@
 Args
+Pydantic
 Ubuntu
+ValidationError
 aclose
 api
 async
@@ -32,6 +34,7 @@ pluggable
 plugins
 pragma
 py
+pydantic
 pyright
 pytest
 readme

--- a/src/coderpad/async_client.py
+++ b/src/coderpad/async_client.py
@@ -7,6 +7,8 @@ from http import HTTPStatus
 from pathlib import Path
 from typing import Self
 
+from beartype import beartype
+
 from coderpad.async_screen import AsyncScreenNamespace
 from coderpad.exceptions import CoderPadError
 from coderpad.screen import SCREEN_US_BASE_URL
@@ -34,6 +36,7 @@ from coderpad.types import (
 )
 
 
+@beartype
 class _AsyncNamespace:
     """Base class providing shared async request logic."""
 
@@ -93,6 +96,7 @@ class _AsyncNamespace:
         return response
 
 
+@beartype
 class AsyncPadsNamespace(_AsyncNamespace):
     """Namespace for async pad operations."""
 
@@ -316,6 +320,7 @@ class AsyncPadsNamespace(_AsyncNamespace):
         return PadHistory.from_dict(data=data)
 
 
+@beartype
 class AsyncQuestionsNamespace(_AsyncNamespace):
     """Namespace for async question operations."""
 
@@ -564,6 +569,7 @@ class AsyncQuestionsNamespace(_AsyncNamespace):
         )
 
 
+@beartype
 class AsyncOrganizationPadsNamespace(_AsyncNamespace):
     """Namespace for async organization pad operations."""
 
@@ -600,6 +606,7 @@ class AsyncOrganizationPadsNamespace(_AsyncNamespace):
         )
 
 
+@beartype
 class AsyncOrganizationQuestionsNamespace(
     _AsyncNamespace,
 ):
@@ -641,6 +648,7 @@ class AsyncOrganizationQuestionsNamespace(
         )
 
 
+@beartype
 class AsyncOrganizationUsersNamespace(_AsyncNamespace):
     """Namespace for async organization user operations."""
 
@@ -671,6 +679,7 @@ class AsyncOrganizationUsersNamespace(_AsyncNamespace):
         ]
 
 
+@beartype
 class AsyncOrganizationNamespace(_AsyncNamespace):
     """Namespace for async organization operations."""
 
@@ -772,6 +781,7 @@ class AsyncOrganizationNamespace(_AsyncNamespace):
         return Quota.model_validate(obj=response.json())
 
 
+@beartype
 class AsyncCoderPad:
     """An async client for the CoderPad Interview API."""
 

--- a/src/coderpad/async_client.py
+++ b/src/coderpad/async_client.py
@@ -7,8 +7,6 @@ from http import HTTPStatus
 from pathlib import Path
 from typing import Self
 
-from beartype import beartype
-
 from coderpad.async_screen import AsyncScreenNamespace
 from coderpad.exceptions import CoderPadError
 from coderpad.screen import SCREEN_US_BASE_URL
@@ -36,7 +34,6 @@ from coderpad.types import (
 )
 
 
-@beartype
 class _AsyncNamespace:
     """Base class providing shared async request logic."""
 
@@ -96,7 +93,6 @@ class _AsyncNamespace:
         return response
 
 
-@beartype
 class AsyncPadsNamespace(_AsyncNamespace):
     """Namespace for async pad operations."""
 
@@ -264,7 +260,7 @@ class AsyncPadsNamespace(_AsyncNamespace):
         )
         data = response.json()
         return PaginatedList(
-            [PadEvent.from_dict(data=item) for item in data["events"]],
+            [PadEvent.model_validate(obj=item) for item in data["events"]],
             total=data["total"],
             next_page=data.get("next_page"),
         )
@@ -320,7 +316,6 @@ class AsyncPadsNamespace(_AsyncNamespace):
         return PadHistory.from_dict(data=data)
 
 
-@beartype
 class AsyncQuestionsNamespace(_AsyncNamespace):
     """Namespace for async question operations."""
 
@@ -352,7 +347,7 @@ class AsyncQuestionsNamespace(_AsyncNamespace):
         )
         data = response.json()
         return PaginatedList(
-            [Question.from_dict(data=item) for item in data["questions"]],
+            [Question.model_validate(obj=item) for item in data["questions"]],
             total=data["total"],
             next_page=data.get("next_page"),
         )
@@ -444,9 +439,7 @@ class AsyncQuestionsNamespace(_AsyncNamespace):
             data=data,
             files=files,
         )
-        return Question.from_dict(
-            data=response.json(),
-        )
+        return Question.model_validate(obj=response.json())
 
     async def get(
         self,
@@ -465,9 +458,7 @@ class AsyncQuestionsNamespace(_AsyncNamespace):
             method="GET",
             url=f"/api/questions/{question_id}",
         )
-        return Question.from_dict(
-            data=response.json(),
-        )
+        return Question.model_validate(obj=response.json())
 
     async def update(
         self,
@@ -573,7 +564,6 @@ class AsyncQuestionsNamespace(_AsyncNamespace):
         )
 
 
-@beartype
 class AsyncOrganizationPadsNamespace(_AsyncNamespace):
     """Namespace for async organization pad operations."""
 
@@ -610,7 +600,6 @@ class AsyncOrganizationPadsNamespace(_AsyncNamespace):
         )
 
 
-@beartype
 class AsyncOrganizationQuestionsNamespace(
     _AsyncNamespace,
 ):
@@ -646,13 +635,12 @@ class AsyncOrganizationQuestionsNamespace(
         )
         data = response.json()
         return PaginatedList(
-            [Question.from_dict(data=item) for item in data["questions"]],
+            [Question.model_validate(obj=item) for item in data["questions"]],
             total=data["total"],
             next_page=data.get("next_page"),
         )
 
 
-@beartype
 class AsyncOrganizationUsersNamespace(_AsyncNamespace):
     """Namespace for async organization user operations."""
 
@@ -678,12 +666,11 @@ class AsyncOrganizationUsersNamespace(_AsyncNamespace):
             params=params,
         )
         return [
-            OrganizationUser.from_dict(data=item)
+            OrganizationUser.model_validate(obj=item)
             for item in response.json()["users"]
         ]
 
 
-@beartype
 class AsyncOrganizationNamespace(_AsyncNamespace):
     """Namespace for async organization operations."""
 
@@ -782,10 +769,9 @@ class AsyncOrganizationNamespace(_AsyncNamespace):
             method="GET",
             url="/api/quota",
         )
-        return Quota.from_dict(data=response.json())
+        return Quota.model_validate(obj=response.json())
 
 
-@beartype
 class AsyncCoderPad:
     """An async client for the CoderPad Interview API."""
 

--- a/src/coderpad/async_screen.py
+++ b/src/coderpad/async_screen.py
@@ -3,8 +3,6 @@
 import builtins
 from http import HTTPStatus
 
-from beartype import beartype
-
 from coderpad.exceptions import CoderPadError
 from coderpad.screen import SCREEN_US_BASE_URL
 from coderpad.screen_types import (
@@ -20,7 +18,6 @@ from coderpad.transports import AsyncJSONTransport, TransportResponse
 _SCREEN_PREFIX = "/assessment/api/v1.1"
 
 
-@beartype
 class _AsyncScreenNamespace:
     """Shared asynchronous Screen request handling."""
 
@@ -57,7 +54,6 @@ class _AsyncScreenNamespace:
         return response
 
 
-@beartype
 class AsyncScreenCampaignsNamespace(_AsyncScreenNamespace):
     """Asynchronous Screen campaign operations."""
 
@@ -77,12 +73,11 @@ class AsyncScreenCampaignsNamespace(_AsyncScreenNamespace):
         response = await self._request(
             method="POST",
             path=f"/campaigns/{campaign_id}/actions/send",
-            json=invitation.to_dict(),
+            json=invitation.model_dump(exclude_none=True),
         )
         return ScreenInvitationResult.from_dict(data=response.json())
 
 
-@beartype
 class AsyncScreenTestsNamespace(_AsyncScreenNamespace):
     """Asynchronous Screen test-session operations."""
 
@@ -193,7 +188,6 @@ class AsyncScreenTestsNamespace(_AsyncScreenNamespace):
         return response.content
 
 
-@beartype
 class AsyncScreenWebhookNamespace(_AsyncScreenNamespace):
     """Asynchronous Screen webhook operations."""
 
@@ -211,7 +205,6 @@ class AsyncScreenWebhookNamespace(_AsyncScreenNamespace):
         await self._request(method="DELETE", path="/webhook")
 
 
-@beartype
 class AsyncScreenNamespace(_AsyncScreenNamespace):
     """Root namespace for the asynchronous Screen API."""
 

--- a/src/coderpad/async_screen.py
+++ b/src/coderpad/async_screen.py
@@ -3,6 +3,8 @@
 import builtins
 from http import HTTPStatus
 
+from beartype import beartype
+
 from coderpad.exceptions import CoderPadError
 from coderpad.screen import SCREEN_US_BASE_URL
 from coderpad.screen_types import (
@@ -18,6 +20,7 @@ from coderpad.transports import AsyncJSONTransport, TransportResponse
 _SCREEN_PREFIX = "/assessment/api/v1.1"
 
 
+@beartype
 class _AsyncScreenNamespace:
     """Shared asynchronous Screen request handling."""
 
@@ -54,6 +57,7 @@ class _AsyncScreenNamespace:
         return response
 
 
+@beartype
 class AsyncScreenCampaignsNamespace(_AsyncScreenNamespace):
     """Asynchronous Screen campaign operations."""
 
@@ -78,6 +82,7 @@ class AsyncScreenCampaignsNamespace(_AsyncScreenNamespace):
         return ScreenInvitationResult.from_dict(data=response.json())
 
 
+@beartype
 class AsyncScreenTestsNamespace(_AsyncScreenNamespace):
     """Asynchronous Screen test-session operations."""
 
@@ -188,6 +193,7 @@ class AsyncScreenTestsNamespace(_AsyncScreenNamespace):
         return response.content
 
 
+@beartype
 class AsyncScreenWebhookNamespace(_AsyncScreenNamespace):
     """Asynchronous Screen webhook operations."""
 
@@ -205,6 +211,7 @@ class AsyncScreenWebhookNamespace(_AsyncScreenNamespace):
         await self._request(method="DELETE", path="/webhook")
 
 
+@beartype
 class AsyncScreenNamespace(_AsyncScreenNamespace):
     """Root namespace for the asynchronous Screen API."""
 

--- a/src/coderpad/client.py
+++ b/src/coderpad/client.py
@@ -7,6 +7,8 @@ from http import HTTPStatus
 from pathlib import Path
 from typing import Self
 
+from beartype import beartype
+
 from coderpad.exceptions import CoderPadError
 from coderpad.screen import SCREEN_US_BASE_URL, ScreenNamespace
 from coderpad.transports import (
@@ -33,6 +35,7 @@ from coderpad.types import (
 )
 
 
+@beartype
 class _Namespace:
     """Base class providing shared request logic."""
 
@@ -92,6 +95,7 @@ class _Namespace:
         return response
 
 
+@beartype
 class PadsNamespace(_Namespace):
     """Namespace for pad operations."""
 
@@ -314,6 +318,7 @@ class PadsNamespace(_Namespace):
         return PadHistory.from_dict(data=data)
 
 
+@beartype
 class QuestionsNamespace(_Namespace):
     """Namespace for question operations."""
 
@@ -560,6 +565,7 @@ class QuestionsNamespace(_Namespace):
         )
 
 
+@beartype
 class OrganizationPadsNamespace(_Namespace):
     """Namespace for organization pad operations."""
 
@@ -596,6 +602,7 @@ class OrganizationPadsNamespace(_Namespace):
         )
 
 
+@beartype
 class OrganizationQuestionsNamespace(_Namespace):
     """Namespace for organization question operations."""
 
@@ -632,6 +639,7 @@ class OrganizationQuestionsNamespace(_Namespace):
         )
 
 
+@beartype
 class OrganizationUsersNamespace(_Namespace):
     """Namespace for organization user operations."""
 
@@ -662,6 +670,7 @@ class OrganizationUsersNamespace(_Namespace):
         ]
 
 
+@beartype
 class OrganizationNamespace(_Namespace):
     """Namespace for organization operations."""
 
@@ -758,6 +767,7 @@ class OrganizationNamespace(_Namespace):
         return Quota.model_validate(obj=response.json())
 
 
+@beartype
 class CoderPad:
     """A client for the CoderPad Interview API."""
 

--- a/src/coderpad/client.py
+++ b/src/coderpad/client.py
@@ -7,8 +7,6 @@ from http import HTTPStatus
 from pathlib import Path
 from typing import Self
 
-from beartype import beartype
-
 from coderpad.exceptions import CoderPadError
 from coderpad.screen import SCREEN_US_BASE_URL, ScreenNamespace
 from coderpad.transports import (
@@ -35,7 +33,6 @@ from coderpad.types import (
 )
 
 
-@beartype
 class _Namespace:
     """Base class providing shared request logic."""
 
@@ -95,7 +92,6 @@ class _Namespace:
         return response
 
 
-@beartype
 class PadsNamespace(_Namespace):
     """Namespace for pad operations."""
 
@@ -262,7 +258,7 @@ class PadsNamespace(_Namespace):
         )
         data = response.json()
         return PaginatedList(
-            [PadEvent.from_dict(data=item) for item in data["events"]],
+            [PadEvent.model_validate(obj=item) for item in data["events"]],
             total=data["total"],
             next_page=data.get("next_page"),
         )
@@ -318,7 +314,6 @@ class PadsNamespace(_Namespace):
         return PadHistory.from_dict(data=data)
 
 
-@beartype
 class QuestionsNamespace(_Namespace):
     """Namespace for question operations."""
 
@@ -349,7 +344,7 @@ class QuestionsNamespace(_Namespace):
         )
         data = response.json()
         return PaginatedList(
-            [Question.from_dict(data=item) for item in data["questions"]],
+            [Question.model_validate(obj=item) for item in data["questions"]],
             total=data["total"],
             next_page=data.get("next_page"),
         )
@@ -440,9 +435,7 @@ class QuestionsNamespace(_Namespace):
             data=data,
             files=files,
         )
-        return Question.from_dict(
-            data=response.json(),
-        )
+        return Question.model_validate(obj=response.json())
 
     def get(
         self,
@@ -461,9 +454,7 @@ class QuestionsNamespace(_Namespace):
             method="GET",
             url=f"/api/questions/{question_id}",
         )
-        return Question.from_dict(
-            data=response.json(),
-        )
+        return Question.model_validate(obj=response.json())
 
     def update(
         self,
@@ -569,7 +560,6 @@ class QuestionsNamespace(_Namespace):
         )
 
 
-@beartype
 class OrganizationPadsNamespace(_Namespace):
     """Namespace for organization pad operations."""
 
@@ -606,7 +596,6 @@ class OrganizationPadsNamespace(_Namespace):
         )
 
 
-@beartype
 class OrganizationQuestionsNamespace(_Namespace):
     """Namespace for organization question operations."""
 
@@ -637,13 +626,12 @@ class OrganizationQuestionsNamespace(_Namespace):
         )
         data = response.json()
         return PaginatedList(
-            [Question.from_dict(data=item) for item in data["questions"]],
+            [Question.model_validate(obj=item) for item in data["questions"]],
             total=data["total"],
             next_page=data.get("next_page"),
         )
 
 
-@beartype
 class OrganizationUsersNamespace(_Namespace):
     """Namespace for organization user operations."""
 
@@ -669,12 +657,11 @@ class OrganizationUsersNamespace(_Namespace):
             params=params,
         )
         return [
-            OrganizationUser.from_dict(data=item)
+            OrganizationUser.model_validate(obj=item)
             for item in response.json()["users"]
         ]
 
 
-@beartype
 class OrganizationNamespace(_Namespace):
     """Namespace for organization operations."""
 
@@ -768,10 +755,9 @@ class OrganizationNamespace(_Namespace):
             method="GET",
             url="/api/quota",
         )
-        return Quota.from_dict(data=response.json())
+        return Quota.model_validate(obj=response.json())
 
 
-@beartype
 class CoderPad:
     """A client for the CoderPad Interview API."""
 

--- a/src/coderpad/screen.py
+++ b/src/coderpad/screen.py
@@ -3,6 +3,8 @@
 import builtins
 from http import HTTPStatus
 
+from beartype import beartype
+
 from coderpad.exceptions import CoderPadError
 from coderpad.screen_types import (
     ScreenCampaign,
@@ -19,6 +21,7 @@ SCREEN_EU_BASE_URL = "https://www.codingame.eu"
 _SCREEN_PREFIX = "/assessment/api/v1.1"
 
 
+@beartype
 class _ScreenNamespace:
     """Shared synchronous Screen request handling."""
 
@@ -55,6 +58,7 @@ class _ScreenNamespace:
         return response
 
 
+@beartype
 class ScreenCampaignsNamespace(_ScreenNamespace):
     """Screen campaign operations."""
 
@@ -79,6 +83,7 @@ class ScreenCampaignsNamespace(_ScreenNamespace):
         return ScreenInvitationResult.from_dict(data=response.json())
 
 
+@beartype
 class ScreenTestsNamespace(_ScreenNamespace):
     """Screen test-session operations."""
 
@@ -178,6 +183,7 @@ class ScreenTestsNamespace(_ScreenNamespace):
         ).content
 
 
+@beartype
 class ScreenWebhookNamespace(_ScreenNamespace):
     """Screen webhook operations."""
 
@@ -195,6 +201,7 @@ class ScreenWebhookNamespace(_ScreenNamespace):
         self._request(method="DELETE", path="/webhook")
 
 
+@beartype
 class ScreenNamespace(_ScreenNamespace):
     """Root namespace for the synchronous Screen API."""
 

--- a/src/coderpad/screen.py
+++ b/src/coderpad/screen.py
@@ -3,8 +3,6 @@
 import builtins
 from http import HTTPStatus
 
-from beartype import beartype
-
 from coderpad.exceptions import CoderPadError
 from coderpad.screen_types import (
     ScreenCampaign,
@@ -21,7 +19,6 @@ SCREEN_EU_BASE_URL = "https://www.codingame.eu"
 _SCREEN_PREFIX = "/assessment/api/v1.1"
 
 
-@beartype
 class _ScreenNamespace:
     """Shared synchronous Screen request handling."""
 
@@ -58,7 +55,6 @@ class _ScreenNamespace:
         return response
 
 
-@beartype
 class ScreenCampaignsNamespace(_ScreenNamespace):
     """Screen campaign operations."""
 
@@ -78,12 +74,11 @@ class ScreenCampaignsNamespace(_ScreenNamespace):
         response = self._request(
             method="POST",
             path=f"/campaigns/{campaign_id}/actions/send",
-            json=invitation.to_dict(),
+            json=invitation.model_dump(exclude_none=True),
         )
         return ScreenInvitationResult.from_dict(data=response.json())
 
 
-@beartype
 class ScreenTestsNamespace(_ScreenNamespace):
     """Screen test-session operations."""
 
@@ -183,7 +178,6 @@ class ScreenTestsNamespace(_ScreenNamespace):
         ).content
 
 
-@beartype
 class ScreenWebhookNamespace(_ScreenNamespace):
     """Screen webhook operations."""
 
@@ -201,7 +195,6 @@ class ScreenWebhookNamespace(_ScreenNamespace):
         self._request(method="DELETE", path="/webhook")
 
 
-@beartype
 class ScreenNamespace(_ScreenNamespace):
     """Root namespace for the synchronous Screen API."""
 

--- a/src/coderpad/screen_types.py
+++ b/src/coderpad/screen_types.py
@@ -2,6 +2,7 @@
 
 from typing import ClassVar, Self, TypeGuard
 
+from beartype import beartype
 from pydantic import BaseModel, ConfigDict, Field
 
 
@@ -81,6 +82,7 @@ def _optional_str(value: object, /) -> str | None:
     return value if isinstance(value, str) else None
 
 
+@beartype
 class ScreenCampaign(_APIModel):
     """A reusable Screen assessment campaign."""
 
@@ -111,6 +113,7 @@ class ScreenCampaign(_APIModel):
         )
 
 
+@beartype
 class ScreenInvitation(_APIModel):
     """An invitation to a Screen campaign."""
 
@@ -122,6 +125,7 @@ class ScreenInvitation(_APIModel):
     send_notification_email_on_bounce: bool | None = None
 
 
+@beartype
 class ScreenInvitationResult(_APIModel):
     """The result of creating a Screen test invitation."""
 
@@ -137,6 +141,7 @@ class ScreenInvitationResult(_APIModel):
         )
 
 
+@beartype
 class ScreenTestQuestion(_APIModel):
     """A question included in a Screen test."""
 
@@ -152,6 +157,7 @@ class ScreenTestQuestion(_APIModel):
         )
 
 
+@beartype
 class ScreenSkillResult(_APIModel):
     """A scored skill within a Screen report."""
 
@@ -169,6 +175,7 @@ class ScreenSkillResult(_APIModel):
         )
 
 
+@beartype
 class ScreenTechnologyResult(_APIModel):
     """A scored technology within a Screen report."""
 
@@ -200,6 +207,7 @@ class ScreenTechnologyResult(_APIModel):
         )
 
 
+@beartype
 class ScreenReport(_APIModel):
     """A candidate's scored Screen report."""
 
@@ -250,6 +258,7 @@ class ScreenReport(_APIModel):
         )
 
 
+@beartype
 class ScreenTest(_APIModel):
     """A candidate's Screen test session."""
 
@@ -297,6 +306,7 @@ class ScreenTest(_APIModel):
         )
 
 
+@beartype
 class ScreenPagination(_APIModel):
     """Offset pagination metadata returned by Screen."""
 
@@ -318,6 +328,7 @@ class ScreenPagination(_APIModel):
         )
 
 
+@beartype
 class ScreenTestsPage(_APIModel):
     """One page of Screen test sessions."""
 
@@ -341,6 +352,7 @@ class ScreenTestsPage(_APIModel):
         )
 
 
+@beartype
 class ScreenWebhook(_APIModel):
     """The configured Screen webhook."""
 

--- a/src/coderpad/screen_types.py
+++ b/src/coderpad/screen_types.py
@@ -1,9 +1,18 @@
 """Types for the CoderPad Screen API."""
 
-from dataclasses import dataclass, field
-from typing import Self, TypeGuard
+from typing import ClassVar, Self, TypeGuard
 
-from beartype import beartype
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class _APIModel(BaseModel):
+    """Base model shared by CoderPad Screen API resources."""
+
+    model_config: ClassVar[ConfigDict] = ConfigDict(
+        frozen=True,
+        extra="ignore",
+        strict=True,
+    )
 
 
 def _is_object_list(value: object, /) -> TypeGuard[list[object]]:
@@ -72,14 +81,12 @@ def _optional_str(value: object, /) -> str | None:
     return value if isinstance(value, str) else None
 
 
-@beartype
-@dataclass(frozen=True, kw_only=True)
-class ScreenCampaign:
+class ScreenCampaign(_APIModel):
     """A reusable Screen assessment campaign."""
 
     id: int
     name: str
-    languages: list[str] = field(default_factory=_empty_strings)
+    languages: list[str] = Field(default_factory=_empty_strings)
     pinned: bool = False
     archived: bool = False
 
@@ -104,9 +111,7 @@ class ScreenCampaign:
         )
 
 
-@beartype
-@dataclass(frozen=True, kw_only=True)
-class ScreenInvitation:
+class ScreenInvitation(_APIModel):
     """An invitation to a Screen campaign."""
 
     candidate_email: str | None = None
@@ -116,26 +121,8 @@ class ScreenInvitation:
     send_invitation_email: bool | None = None
     send_notification_email_on_bounce: bool | None = None
 
-    def to_dict(self) -> dict[str, str | bool]:
-        """Create the JSON request body, omitting unset fields."""
-        values: dict[str, str | bool | None] = {
-            "candidate_email": self.candidate_email,
-            "candidate_name": self.candidate_name,
-            "recruiter_email": self.recruiter_email,
-            "tags": self.tags,
-            "send_invitation_email": self.send_invitation_email,
-            "send_notification_email_on_bounce": (
-                self.send_notification_email_on_bounce
-            ),
-        }
-        return {
-            key: value for key, value in values.items() if value is not None
-        }
 
-
-@beartype
-@dataclass(frozen=True, kw_only=True)
-class ScreenInvitationResult:
+class ScreenInvitationResult(_APIModel):
     """The result of creating a Screen test invitation."""
 
     id: int | None
@@ -150,9 +137,7 @@ class ScreenInvitationResult:
         )
 
 
-@beartype
-@dataclass(frozen=True, kw_only=True)
-class ScreenTestQuestion:
+class ScreenTestQuestion(_APIModel):
     """A question included in a Screen test."""
 
     id: int
@@ -167,9 +152,7 @@ class ScreenTestQuestion:
         )
 
 
-@beartype
-@dataclass(frozen=True, kw_only=True)
-class ScreenSkillResult:
+class ScreenSkillResult(_APIModel):
     """A scored skill within a Screen report."""
 
     points: int | None
@@ -186,9 +169,7 @@ class ScreenSkillResult:
         )
 
 
-@beartype
-@dataclass(frozen=True, kw_only=True)
-class ScreenTechnologyResult:
+class ScreenTechnologyResult(_APIModel):
     """A scored technology within a Screen report."""
 
     points: int | None
@@ -219,9 +200,7 @@ class ScreenTechnologyResult:
         )
 
 
-@beartype
-@dataclass(frozen=True, kw_only=True)
-class ScreenReport:
+class ScreenReport(_APIModel):
     """A candidate's scored Screen report."""
 
     duration: int | None
@@ -271,9 +250,7 @@ class ScreenReport:
         )
 
 
-@beartype
-@dataclass(frozen=True, kw_only=True)
-class ScreenTest:
+class ScreenTest(_APIModel):
     """A candidate's Screen test session."""
 
     id: int
@@ -320,9 +297,7 @@ class ScreenTest:
         )
 
 
-@beartype
-@dataclass(frozen=True, kw_only=True)
-class ScreenPagination:
+class ScreenPagination(_APIModel):
     """Offset pagination metadata returned by Screen."""
 
     start: int | None
@@ -343,9 +318,7 @@ class ScreenPagination:
         )
 
 
-@beartype
-@dataclass(frozen=True, kw_only=True)
-class ScreenTestsPage:
+class ScreenTestsPage(_APIModel):
     """One page of Screen test sessions."""
 
     tests: list[ScreenTest]
@@ -368,9 +341,7 @@ class ScreenTestsPage:
         )
 
 
-@beartype
-@dataclass(frozen=True, kw_only=True)
-class ScreenWebhook:
+class ScreenWebhook(_APIModel):
     """The configured Screen webhook."""
 
     url: str | None

--- a/src/coderpad/transports.py
+++ b/src/coderpad/transports.py
@@ -6,6 +6,7 @@ from http import HTTPStatus
 from typing import Any, Protocol, Self, runtime_checkable
 
 import httpx
+from beartype import beartype
 
 
 class HTTPStatusError(Exception):
@@ -29,6 +30,7 @@ class HTTPStatusError(Exception):
         self.content = content
 
 
+@beartype
 @dataclass(frozen=True, kw_only=True)
 class TransportResponse:
     """A response from a transport."""
@@ -114,6 +116,7 @@ class JSONTransport(Protocol):
         ...  # pylint: disable=unnecessary-ellipsis
 
 
+@beartype
 class HTTPXTransport:
     """HTTP transport using the ``httpx`` library.
 
@@ -244,6 +247,7 @@ class AsyncJSONTransport(Protocol):
         ...  # pylint: disable=unnecessary-ellipsis
 
 
+@beartype
 class AsyncHTTPXTransport:
     """Async HTTP transport using the ``httpx`` library.
 

--- a/src/coderpad/transports.py
+++ b/src/coderpad/transports.py
@@ -6,7 +6,6 @@ from http import HTTPStatus
 from typing import Any, Protocol, Self, runtime_checkable
 
 import httpx
-from beartype import beartype
 
 
 class HTTPStatusError(Exception):
@@ -30,7 +29,6 @@ class HTTPStatusError(Exception):
         self.content = content
 
 
-@beartype
 @dataclass(frozen=True, kw_only=True)
 class TransportResponse:
     """A response from a transport."""
@@ -116,7 +114,6 @@ class JSONTransport(Protocol):
         ...  # pylint: disable=unnecessary-ellipsis
 
 
-@beartype
 class HTTPXTransport:
     """HTTP transport using the ``httpx`` library.
 
@@ -247,7 +244,6 @@ class AsyncJSONTransport(Protocol):
         ...  # pylint: disable=unnecessary-ellipsis
 
 
-@beartype
 class AsyncHTTPXTransport:
     """Async HTTP transport using the ``httpx`` library.
 

--- a/src/coderpad/types.py
+++ b/src/coderpad/types.py
@@ -2,10 +2,9 @@
 
 import enum
 from collections.abc import Iterable
-from dataclasses import dataclass, field
-from typing import Self, TypeVar
+from typing import ClassVar, Self, TypeVar
 
-from beartype import beartype
+from pydantic import BaseModel, ConfigDict, Field
 
 from coderpad._dict_types import (
     CandidateInstructionDict,
@@ -33,7 +32,16 @@ from coderpad._dict_types import (
 _T = TypeVar("_T")
 
 
-@beartype
+class _APIModel(BaseModel):
+    """Base model shared by CoderPad API resources."""
+
+    model_config: ClassVar[ConfigDict] = ConfigDict(
+        frozen=True,
+        extra="ignore",
+        strict=True,
+    )
+
+
 class PaginatedList(list[_T]):
     """A list with pagination metadata from the API response."""
 
@@ -147,9 +155,7 @@ class Language(enum.Enum):
     VUE = "vue"
 
 
-@beartype
-@dataclass(frozen=True, kw_only=True)
-class Team:
+class Team(_APIModel):
     """A team within an organization."""
 
     id: str
@@ -171,9 +177,7 @@ class Team:
         )
 
 
-@beartype
-@dataclass(frozen=True, kw_only=True)
-class PadInterviewerNotification:
+class PadInterviewerNotification(_APIModel):
     """An interviewer notification associated with a pad.
 
     This structure is empirically observed in live API responses and is not
@@ -223,9 +227,7 @@ def _empty_pad_interviewer_notifications() -> list[PadInterviewerNotification]:
     return []
 
 
-@beartype
-@dataclass(frozen=True, kw_only=True)
-class Pad:
+class Pad(_APIModel):
     """A CoderPad interview pad."""
 
     id: str
@@ -252,7 +254,7 @@ class Pad:
     team: Team
     history: str | None = None
     restrict_interviewer_access: bool | None = None
-    pad_interviewer_notifications: list[PadInterviewerNotification] = field(
+    pad_interviewer_notifications: list[PadInterviewerNotification] = Field(
         default_factory=_empty_pad_interviewer_notifications,
     )
 
@@ -308,9 +310,7 @@ class Pad:
         )
 
 
-@beartype
-@dataclass(frozen=True, kw_only=True)
-class PadEvent:
+class PadEvent(_APIModel):
     """An event associated with a pad."""
 
     message: str
@@ -343,9 +343,7 @@ class PadEvent:
         )
 
 
-@beartype
-@dataclass(frozen=True, kw_only=True)
-class PadHistoryEntry:
+class PadHistoryEntry(_APIModel):
     """An editor operation from a pad's Firebase history.
 
     Positive integer operations retain existing characters, negative
@@ -403,7 +401,6 @@ class PadHistoryEntry:
         return "".join(updated)
 
 
-@beartype
 class PadHistory(list[PadHistoryEntry]):
     """Chronologically ordered editor history for a pad file."""
 
@@ -450,9 +447,7 @@ class PadHistory(list[PadHistoryEntry]):
         return contents
 
 
-@beartype
-@dataclass(frozen=True, kw_only=True)
-class FileContent:
+class FileContent(_APIModel):
     """A file within a pad environment.
 
     Binary files are empirically observed with ``binary`` set to ``True`` and
@@ -487,9 +482,7 @@ class FileContent:
         )
 
 
-@beartype
-@dataclass(frozen=True, kw_only=True)
-class PadEnvironment:
+class PadEnvironment(_APIModel):
     """A pad environment."""
 
     id: int
@@ -531,9 +524,7 @@ class PadEnvironment:
         )
 
 
-@beartype
-@dataclass(frozen=True, kw_only=True)
-class QuestionFileContent:
+class QuestionFileContent(_APIModel):
     """A file for a multi-file question.
 
     Used when creating or updating questions with
@@ -544,9 +535,7 @@ class QuestionFileContent:
     contents: str
 
 
-@beartype
-@dataclass(frozen=True, kw_only=True)
-class CandidateInstruction:
+class CandidateInstruction(_APIModel):
     """Instructions shown to a candidate."""
 
     instructions: str
@@ -573,9 +562,7 @@ class CandidateInstruction:
         )
 
 
-@beartype
-@dataclass(frozen=True, kw_only=True)
-class TestCase:
+class TestCase(_APIModel):
     """A test case for a question."""
 
     id: int
@@ -604,9 +591,7 @@ class TestCase:
         )
 
 
-@beartype
-@dataclass(frozen=True, kw_only=True)
-class CustomFile:
+class CustomFile(_APIModel):
     """A custom file attached to a question."""
 
     id: str
@@ -637,9 +622,7 @@ class CustomFile:
         )
 
 
-@beartype
-@dataclass(frozen=True, kw_only=True)
-class CustomDatabaseColumn:
+class CustomDatabaseColumn(_APIModel):
     """A column in a question's custom database schema."""
 
     name: str
@@ -668,9 +651,7 @@ class CustomDatabaseColumn:
         )
 
 
-@beartype
-@dataclass(frozen=True, kw_only=True)
-class CustomDatabaseTable:
+class CustomDatabaseTable(_APIModel):
     """A table in a question's custom database schema."""
 
     name: str
@@ -698,9 +679,7 @@ class CustomDatabaseTable:
         )
 
 
-@beartype
-@dataclass(frozen=True, kw_only=True)
-class CustomDatabaseSchema:
+class CustomDatabaseSchema(_APIModel):
     """The structured schema for a question's custom database."""
 
     arrangement: str
@@ -728,9 +707,7 @@ class CustomDatabaseSchema:
         )
 
 
-@beartype
-@dataclass(frozen=True, kw_only=True)
-class CustomDatabase:
+class CustomDatabase(_APIModel):
     """A custom database attached to a question.
 
     This structure is empirically observed in live API responses and is not
@@ -741,8 +718,8 @@ class CustomDatabase:
     title: str
     description: str
     language: str
-    schema: str
-    schema_json: CustomDatabaseSchema
+    schema: str  # type: ignore[assignment]  # pyright: ignore[reportIncompatibleMethodOverride]
+    schema_json: CustomDatabaseSchema  # type: ignore[assignment]  # pyright: ignore[reportIncompatibleMethodOverride]
 
     @classmethod
     def from_dict(
@@ -769,9 +746,7 @@ class CustomDatabase:
         )
 
 
-@beartype
-@dataclass(frozen=True, kw_only=True)
-class Question:
+class Question(_APIModel):
     """A CoderPad question."""
 
     id: int
@@ -862,9 +837,7 @@ class Question:
         )
 
 
-@beartype
-@dataclass(frozen=True, kw_only=True)
-class OrganizationUser:
+class OrganizationUser(_APIModel):
     """A user within an organization."""
 
     email: str
@@ -891,9 +864,7 @@ class OrganizationUser:
         )
 
 
-@beartype
-@dataclass(frozen=True, kw_only=True)
-class OrganizationStatsUser:
+class OrganizationStatsUser(_APIModel):
     """A user's pad usage statistics."""
 
     email: str
@@ -920,9 +891,7 @@ class OrganizationStatsUser:
         )
 
 
-@beartype
-@dataclass(frozen=True, kw_only=True)
-class Quota:
+class Quota(_APIModel):
     """Quota information."""
 
     trial_expires_at: str
@@ -958,9 +927,7 @@ def _empty_child_organizations() -> list[dict[str, object]]:
     return []
 
 
-@beartype
-@dataclass(frozen=True, kw_only=True)
-class Organization:
+class Organization(_APIModel):
     """Organization information.
 
     ``id`` and ``child_organizations`` are empirically observed fields that
@@ -976,7 +943,7 @@ class Organization:
     teams: list[Team]
     single_sign_in_url: str | None = None
     id: int | None = None
-    child_organizations: list[dict[str, object]] = field(
+    child_organizations: list[dict[str, object]] = Field(
         default_factory=_empty_child_organizations,
     )
 
@@ -1015,9 +982,7 @@ class Organization:
         )
 
 
-@beartype
-@dataclass(frozen=True, kw_only=True)
-class OrganizationStats:
+class OrganizationStats(_APIModel):
     """Organization usage statistics."""
 
     start_time: str

--- a/src/coderpad/types.py
+++ b/src/coderpad/types.py
@@ -742,6 +742,9 @@ class CustomDatabase(_APIModel):
     title: str
     description: str
     language: str
+    # These API field names intentionally shadow deprecated BaseModel methods.
+    # Pydantic supports this at runtime (pydantic/pydantic#11912), but static
+    # type checkers still treat the fields as incompatible method overrides.
     schema: str  # type: ignore[assignment]  # pyright: ignore[reportIncompatibleMethodOverride]
     schema_json: CustomDatabaseSchema  # type: ignore[assignment]  # pyright: ignore[reportIncompatibleMethodOverride]
 

--- a/src/coderpad/types.py
+++ b/src/coderpad/types.py
@@ -4,7 +4,7 @@ import enum
 from collections.abc import Iterable
 from typing import ClassVar, Self, TypeVar
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from coderpad._dict_types import (
     CandidateInstructionDict,
@@ -190,8 +190,8 @@ class PadInterviewerNotification(_APIModel):
     priority: str
     request_id: str
     auto_dismissed: bool
-    dismissed_at: str | None
-    useful: bool | None
+    dismissed_at: str | None = None
+    useful: bool | None = None
     created_at: str
     updated_at: str
 
@@ -234,23 +234,23 @@ class Pad(_APIModel):
     title: str
     state: str
     owner_email: str
-    language: str | None
+    language: str | None = None
     private: bool
     execution_enabled: bool
-    contents: str | None
+    contents: str | None = None
     participants: list[str]
     events: str
-    notes: str | None
+    notes: str | None = None
     created_at: str
     updated_at: str
-    ended_at: str | None
+    ended_at: str | None = None
     url: str
     playback: str
-    drawing: str | None
+    drawing: str | None = None
     type: str
     question_ids: list[int]
     pad_environment_ids: list[int]
-    active_environment_id: int | None
+    active_environment_id: int | None = None
     team: Team
     history: str | None = None
     restrict_interviewer_access: bool | None = None
@@ -315,9 +315,9 @@ class PadEvent(_APIModel):
 
     message: str
     kind: str
-    metadata: str | None
-    user_name: str | None
-    user_email: str | None
+    metadata: str | None = None
+    user_name: str | None = None
+    user_email: str | None = None
     created_at: str
 
     @classmethod
@@ -457,7 +457,7 @@ class FileContent(_APIModel):
 
     path: str
     contents: str | None
-    history: str | None
+    history: str | None = None
     binary: bool = False
 
     @classmethod
@@ -487,8 +487,8 @@ class PadEnvironment(_APIModel):
 
     id: int
     pad_id: int
-    question_id: int | None
-    example_question_id: int | None
+    question_id: int | None = None
+    example_question_id: int | None = None
     language: str
     file_contents: list[FileContent]
     created_at: str
@@ -540,6 +540,12 @@ class CandidateInstruction(_APIModel):
 
     instructions: str
     default_visible: bool = False
+
+    @field_validator("default_visible", mode="before")
+    @classmethod
+    def _none_is_not_visible(cls, value: object) -> object:
+        """Normalize a null API value to the legacy false default."""
+        return False if value is None else value
 
     @classmethod
     def from_dict(
@@ -752,15 +758,15 @@ class Question(_APIModel):
     id: int
     title: str
     owner_email: str
-    language: str | None
-    description: str | None
+    language: str | None = None
+    description: str | None = None
     candidate_instructions: list[CandidateInstruction]
-    contents: str | None
+    contents: str | None = None
     shared: bool
     used: int
     take_home: bool
     test_cases_enabled: bool
-    solution: str | None
+    solution: str | None = None
     pad_type: str
     is_draft: bool
     author_name: str

--- a/src/coderpad/types.py
+++ b/src/coderpad/types.py
@@ -4,6 +4,7 @@ import enum
 from collections.abc import Iterable
 from typing import ClassVar, Self, TypeVar
 
+from beartype import beartype
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from coderpad._dict_types import (
@@ -42,6 +43,7 @@ class _APIModel(BaseModel):
     )
 
 
+@beartype
 class PaginatedList(list[_T]):
     """A list with pagination metadata from the API response."""
 
@@ -155,6 +157,7 @@ class Language(enum.Enum):
     VUE = "vue"
 
 
+@beartype
 class Team(_APIModel):
     """A team within an organization."""
 
@@ -177,6 +180,7 @@ class Team(_APIModel):
         )
 
 
+@beartype
 class PadInterviewerNotification(_APIModel):
     """An interviewer notification associated with a pad.
 
@@ -227,6 +231,7 @@ def _empty_pad_interviewer_notifications() -> list[PadInterviewerNotification]:
     return []
 
 
+@beartype
 class Pad(_APIModel):
     """A CoderPad interview pad."""
 
@@ -310,6 +315,7 @@ class Pad(_APIModel):
         )
 
 
+@beartype
 class PadEvent(_APIModel):
     """An event associated with a pad."""
 
@@ -343,6 +349,7 @@ class PadEvent(_APIModel):
         )
 
 
+@beartype
 class PadHistoryEntry(_APIModel):
     """An editor operation from a pad's Firebase history.
 
@@ -401,6 +408,7 @@ class PadHistoryEntry(_APIModel):
         return "".join(updated)
 
 
+@beartype
 class PadHistory(list[PadHistoryEntry]):
     """Chronologically ordered editor history for a pad file."""
 
@@ -447,6 +455,7 @@ class PadHistory(list[PadHistoryEntry]):
         return contents
 
 
+@beartype
 class FileContent(_APIModel):
     """A file within a pad environment.
 
@@ -482,6 +491,7 @@ class FileContent(_APIModel):
         )
 
 
+@beartype
 class PadEnvironment(_APIModel):
     """A pad environment."""
 
@@ -524,6 +534,7 @@ class PadEnvironment(_APIModel):
         )
 
 
+@beartype
 class QuestionFileContent(_APIModel):
     """A file for a multi-file question.
 
@@ -535,6 +546,7 @@ class QuestionFileContent(_APIModel):
     contents: str
 
 
+@beartype
 class CandidateInstruction(_APIModel):
     """Instructions shown to a candidate."""
 
@@ -568,6 +580,7 @@ class CandidateInstruction(_APIModel):
         )
 
 
+@beartype
 class TestCase(_APIModel):
     """A test case for a question."""
 
@@ -597,6 +610,7 @@ class TestCase(_APIModel):
         )
 
 
+@beartype
 class CustomFile(_APIModel):
     """A custom file attached to a question."""
 
@@ -628,6 +642,7 @@ class CustomFile(_APIModel):
         )
 
 
+@beartype
 class CustomDatabaseColumn(_APIModel):
     """A column in a question's custom database schema."""
 
@@ -657,6 +672,7 @@ class CustomDatabaseColumn(_APIModel):
         )
 
 
+@beartype
 class CustomDatabaseTable(_APIModel):
     """A table in a question's custom database schema."""
 
@@ -685,6 +701,7 @@ class CustomDatabaseTable(_APIModel):
         )
 
 
+@beartype
 class CustomDatabaseSchema(_APIModel):
     """The structured schema for a question's custom database."""
 
@@ -713,6 +730,7 @@ class CustomDatabaseSchema(_APIModel):
         )
 
 
+@beartype
 class CustomDatabase(_APIModel):
     """A custom database attached to a question.
 
@@ -752,6 +770,7 @@ class CustomDatabase(_APIModel):
         )
 
 
+@beartype
 class Question(_APIModel):
     """A CoderPad question."""
 
@@ -843,6 +862,7 @@ class Question(_APIModel):
         )
 
 
+@beartype
 class OrganizationUser(_APIModel):
     """A user within an organization."""
 
@@ -870,6 +890,7 @@ class OrganizationUser(_APIModel):
         )
 
 
+@beartype
 class OrganizationStatsUser(_APIModel):
     """A user's pad usage statistics."""
 
@@ -897,6 +918,7 @@ class OrganizationStatsUser(_APIModel):
         )
 
 
+@beartype
 class Quota(_APIModel):
     """Quota information."""
 
@@ -933,6 +955,7 @@ def _empty_child_organizations() -> list[dict[str, object]]:
     return []
 
 
+@beartype
 class Organization(_APIModel):
     """Organization information.
 
@@ -988,6 +1011,7 @@ class Organization(_APIModel):
         )
 
 
+@beartype
 class OrganizationStats(_APIModel):
     """Organization usage statistics."""
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,5 +1,8 @@
 """Tests for the CoderPad types."""
 
+import pytest
+from pydantic import ValidationError
+
 from coderpad._dict_types import (
     CandidateInstructionDict,
     CustomDatabaseDict,
@@ -236,6 +239,20 @@ class TestTeam:
         result = Team.from_dict(data=data)
         assert result.id == data["id"]
         assert result.name == data["name"]
+
+    @staticmethod
+    def test_pydantic_validation_and_serialization() -> None:
+        """Models validate strictly, ignore new API fields, and
+        serialize.
+        """
+        team = Team.model_validate(
+            obj={"id": "team-1", "name": "Backend", "future_field": True},
+        )
+        assert team.model_dump() == {"id": "team-1", "name": "Backend"}
+        with pytest.raises(expected_exception=ValidationError):
+            Team.model_validate(obj={"id": 1, "name": "Backend"})
+        with pytest.raises(expected_exception=ValidationError):
+            setattr(team, "name", "Frontend")  # noqa: B010
 
 
 class TestPad:

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -343,7 +343,7 @@ class TestPadEvent:
 
     @staticmethod
     def test_model_validate_without_optional_fields() -> None:
-        """Pydantic parsing accepts omitted nullable response fields."""
+        """Pydantic parsing accepts omitted optional response fields."""
         result = PadEvent.model_validate(
             obj={
                 "message": "Pad started",
@@ -552,7 +552,7 @@ class TestQuestion:
 
     @staticmethod
     def test_model_validate_without_optional_fields() -> None:
-        """Pydantic parsing accepts omitted nullable response fields."""
+        """Pydantic parsing accepts omitted optional response fields."""
         payload: dict[str, object] = dict(_question_dict())
         for field_name in (
             "language",

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -251,8 +251,15 @@ class TestTeam:
         assert team.model_dump() == {"id": "team-1", "name": "Backend"}
         with pytest.raises(expected_exception=ValidationError):
             Team.model_validate(obj={"id": 1, "name": "Backend"})
-        with pytest.raises(expected_exception=ValidationError):
-            setattr(team, "name", "Frontend")  # noqa: B010
+        with (
+            pytest.MonkeyPatch.context() as monkeypatch,
+            pytest.raises(expected_exception=ValidationError),
+        ):
+            monkeypatch.setattr(
+                target=team,
+                name="name",
+                value="Frontend",
+            )
 
 
 class TestPad:
@@ -557,7 +564,7 @@ class TestCustomDatabase:
         data = _custom_database_dict()
         result = CustomDatabase.from_dict(data=data)
         assert result.id == data["id"]
-        assert result.schema == data["schema"]
+        assert result.schema == data["schema"]  # pylint: disable=comparison-with-callable
         assert result.schema_json.arrangement == "horizontal"
         assert result.schema_json.tables[0].name == "products"
         assert result.schema_json.tables[0].columns[0].nn

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -341,6 +341,20 @@ class TestPadEvent:
         assert result.user_email == data["user_email"]
         assert result.created_at == data["created_at"]
 
+    @staticmethod
+    def test_model_validate_without_optional_fields() -> None:
+        """Pydantic parsing accepts omitted nullable response fields."""
+        result = PadEvent.model_validate(
+            obj={
+                "message": "Pad started",
+                "kind": "start",
+                "created_at": "2023-01-01T00:00:00Z",
+            },
+        )
+        assert result.metadata is None
+        assert result.user_name is None
+        assert result.user_email is None
+
 
 class TestFileContent:
     """Tests for ``FileContent``."""
@@ -458,6 +472,14 @@ class TestCandidateInstruction:
         assert result.instructions == data["instructions"]
         assert result.default_visible is True
 
+    @staticmethod
+    def test_model_validate_normalizes_null_visibility() -> None:
+        """Pydantic parsing retains legacy null visibility handling."""
+        result = CandidateInstruction.model_validate(
+            obj={"instructions": "Do the thing", "default_visible": None},
+        )
+        assert result.default_visible is False
+
 
 class TestTestCase:
     """Tests for ``TestCase``."""
@@ -527,6 +549,32 @@ class TestQuestion:
         assert result.custom_database.title == "Products"
         assert result.custom_database.schema_json.tables[0].columns[0].pk
         assert result.ai_assist_custom_system_prompt == "Only provide hints."
+
+    @staticmethod
+    def test_model_validate_without_optional_fields() -> None:
+        """Pydantic parsing accepts omitted nullable response fields."""
+        payload: dict[str, object] = dict(_question_dict())
+        for field_name in (
+            "language",
+            "description",
+            "contents",
+            "solution",
+            "public_take_home_setting_id",
+            "contents_for_test_cases",
+            "test_cases",
+            "custom_database",
+            "ai_assist_custom_system_prompt",
+        ):
+            payload.pop(field_name)
+        payload["candidate_instructions"] = [
+            {"instructions": "Do the thing", "default_visible": None},
+        ]
+
+        result = Question.model_validate(obj=payload)
+
+        assert result.language is None
+        assert result.solution is None
+        assert result.candidate_instructions[0].default_visible is False
 
     @staticmethod
     def test_from_dict_with_null_ai_assist_custom_system_prompt() -> None:


### PR DESCRIPTION
## Summary

- migrate Interview and Screen API resource dataclasses to strict, frozen Pydantic v2 models
- validate API responses with `model_validate` and serialize request models with `model_dump`
- retain `beartype` runtime validation across models, clients, namespaces, and transports
- retain custom pad-history parsing, tolerant Screen response normalization, and legacy `from_dict` compatibility helpers
- add coverage for strict validation, forward-compatible extra fields, serialization, immutability, omitted optional fields, and legacy null normalization

## Why

The SDK previously maintained runtime-validated dataclasses, parallel `TypedDict` response schemas, and handwritten conversion logic. Pydantic provides a consistent model boundary with nested validation and standard serialization, while `beartype` continues to enforce runtime annotations throughout the public SDK surface.

## Impact

API resource objects are now Pydantic models. They remain immutable and keyword-oriented, ignore unknown response fields for forward compatibility, and reject invalid known field types strictly. Consumers can use `model_validate` and `model_dump`; existing `from_dict` helpers remain available. Beartype validation remains enabled alongside Pydantic.

## Validation

- 173 tests passed
- all repository commit, pre-push, and manual hooks passed
- mypy passed
- Pyright and `pyright --verifytypes` passed with 100% type completeness
- ty passed
- Pyrefly passed
- Ruff and Pylint passed
- documentation, spelling, and link checks passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public return types are now Pydantic models with strict validation, which can raise ValidationError on bad API payloads where parsing previously succeeded; behavior is mostly preserved via from_dict, extra=ignore, and targeted validators.
> 
> **Overview**
> Interview and Screen **API resource types** move from frozen dataclasses to a shared **`_APIModel`** base (`frozen`, `strict`, `extra="ignore"`). **`pydantic>=2.12.0`** is added as a runtime dependency; **beartype** stays on the public surface.
> 
> **Clients** parse several responses with **`model_validate`** instead of **`from_dict`** (e.g. pad events, questions, org users, quota). **Screen invitations** serialize with **`model_dump(exclude_none=True)`** instead of a custom **`to_dict`**. **`from_dict`** helpers remain for compatibility and for paths not yet switched (e.g. pads, organization).
> 
> **`CandidateInstruction`** gains a Pydantic validator so **`default_visible: null`** still maps to **`False`**. **`CustomDatabase`** keeps API field names **`schema`** / **`schema_json`** with type-checker suppressions. Sphinx autodoc **excludes** **`__init__`** and **`model_config`** on type modules.
> 
> Tests cover strict validation, ignoring unknown fields, immutability, optional fields, and null visibility normalization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4c2fc6bb55a7af852731cfd572371cc8cb95dd8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->