### PR TITLE
Validate request bodies in OpenAPI-backed mock

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -6,13 +6,14 @@ from doctest import ELLIPSIS
 
 import pytest
 import respx
-from openapi_mock import add_openapi_to_respx
 from sybil import Sybil
 from sybil.parsers.rest import (
     ClearNamespaceParser,
     DocTestParser,
     PythonCodeBlockParser,
 )
+
+from tests.openapi_mock import JSONMapping, add_openapi_to_respx
 
 _BASE_URL = "https://app.coderpad.io"
 
@@ -24,7 +25,7 @@ def fixture_mock_coderpad_api(
     """Provide a respx mock router backed by the OpenAPI spec."""
     openapi_spec_path = request.config.rootpath / "openapi.json"
     spec_text = openapi_spec_path.read_text(encoding="utf-8")
-    openapi_spec: dict[str, object] = json.loads(s=spec_text)
+    openapi_spec: JSONMapping = json.loads(s=spec_text)
     with respx.mock(
         base_url=_BASE_URL,
         assert_all_called=False,

--- a/newsfragments/233.change
+++ b/newsfragments/233.change
@@ -1,0 +1,2 @@
+Validate client form requests against request-body schemas in the bundled
+OpenAPI specification during tests.

--- a/newsfragments/233.change
+++ b/newsfragments/233.change
@@ -1,2 +1,2 @@
-Validate client form requests against request-body schemas in the bundled
+Validate client form requests against request-body definitions in the bundled
 OpenAPI specification during tests.

--- a/openapi.json
+++ b/openapi.json
@@ -415,6 +415,15 @@
       },
       "post": {
         "summary": "Create a pad",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/PadCreateForm"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Successful request",
@@ -1041,6 +1050,15 @@
       ],
       "put": {
         "summary": "Modify a pad",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/PadUpdateForm"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Successful request",
@@ -2075,6 +2093,20 @@
       ],
       "put": {
         "summary": "Modify a question",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/QuestionForm"
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/QuestionForm"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Successful request",
@@ -2863,6 +2895,29 @@
       },
       "post": {
         "summary": "Create a question",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/QuestionForm",
+                "required": [
+                  "question[title]",
+                  "question[language]"
+                ]
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/QuestionForm",
+                "required": [
+                  "question[title]",
+                  "question[language]"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Successful request",
@@ -4816,6 +4871,97 @@
     }
   },
   "components": {
+    "schemas": {
+      "PadCreateForm": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "language": {
+            "type": "string"
+          },
+          "contents": {
+            "type": "string"
+          },
+          "notes": {
+            "type": "string"
+          },
+          "question_id": {
+            "type": "string"
+          }
+        }
+      },
+      "PadUpdateForm": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "language": {
+            "type": "string"
+          },
+          "contents": {
+            "type": "string"
+          },
+          "notes": {
+            "type": "string"
+          },
+          "ended": {
+            "type": "string",
+            "enum": [
+              "true",
+              "false"
+            ]
+          },
+          "deleted": {
+            "type": "string",
+            "enum": [
+              "true",
+              "false"
+            ]
+          }
+        }
+      },
+      "QuestionForm": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "question[title]": {
+            "type": "string"
+          },
+          "question[language]": {
+            "type": "string"
+          },
+          "question[description]": {
+            "type": "string"
+          },
+          "question[contents]": {
+            "type": "string"
+          },
+          "question[solution]": {
+            "type": "string"
+          },
+          "question[ai_assist_custom_system_prompt]": {
+            "type": "string"
+          },
+          "question[candidate_instructions]": {
+            "type": "string",
+            "contentMediaType": "application/json"
+          },
+          "question[file_contents]": {
+            "type": "string",
+            "contentMediaType": "application/json"
+          },
+          "question[zip_file]": {
+            "type": "string",
+            "format": "binary"
+          }
+        }
+      }
+    },
     "securitySchemes": {
       "BearerAuth": {
         "type": "http",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -431,6 +431,7 @@ plugins = [
 ]
 
 [tool.pyrefly]
+search_path = [ "." ]
 errors.non-exhaustive-match = "error"
 
 [tool.pyright]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,11 +6,11 @@ from http import HTTPStatus
 
 import pytest
 import respx
-from openapi_mock import add_openapi_to_respx
 
 from coderpad.async_client import AsyncCoderPad
 from coderpad.client import CoderPad
 from coderpad.transports import TransportResponse
+from tests.openapi_mock import JSONMapping, add_openapi_to_respx
 
 _BASE_URL = "https://app.coderpad.io"
 _LIVE_VARIANT_ORGANIZATION_ID = 42
@@ -113,17 +113,17 @@ def _question_payload() -> dict[str, object]:
 
 
 @pytest.fixture(name="openapi_spec")
-def fixture_openapi_spec(request: pytest.FixtureRequest) -> dict[str, object]:
+def fixture_openapi_spec(request: pytest.FixtureRequest) -> JSONMapping:
     """Load the OpenAPI spec from the repo."""
     openapi_spec_path = request.config.rootpath / "openapi.json"
     spec_text = openapi_spec_path.read_text(encoding="utf-8")
-    result: dict[str, object] = json.loads(s=spec_text)
+    result: JSONMapping = json.loads(s=spec_text)
     return result
 
 
 @pytest.fixture(name="mock_coderpad_api")
 def fixture_mock_coderpad_api(
-    openapi_spec: dict[str, object],
+    openapi_spec: JSONMapping,
 ) -> Generator[respx.MockRouter]:
     """Provide a respx mock router backed by the OpenAPI spec."""
     with respx.mock(

--- a/tests/openapi_mock.py
+++ b/tests/openapi_mock.py
@@ -58,14 +58,13 @@ def _operations(*, spec: JSONMapping) -> Iterator[JSONMapping]:
     assert isinstance(paths_object, dict)
     paths: JSONMapping = paths_object
     for path_item_object in paths.values():
-        if not isinstance(path_item_object, dict):  # pragma: no cover
-            continue
+        assert isinstance(path_item_object, dict)
         path_item: JSONMapping = path_item_object
         for method, operation in path_item.items():
             if method.lower() not in _HTTP_METHODS:
                 continue
-            if isinstance(operation, dict):  # pragma: no branch
-                yield operation
+            assert isinstance(operation, dict)
+            yield operation
 
 
 def _request_validator(

--- a/tests/openapi_mock.py
+++ b/tests/openapi_mock.py
@@ -26,7 +26,7 @@ def add_openapi_to_respx(
     base_url: str,
 ) -> None:
     """Add response routes and validate requests with their OpenAPI
-    schemas.
+    definitions.
     """
     initial_route_count = len(mock_obj.routes)
     add_response_routes(mock_obj=mock_obj, spec=spec, base_url=base_url)

--- a/tests/openapi_mock.py
+++ b/tests/openapi_mock.py
@@ -1,0 +1,238 @@
+"""OpenAPI-backed RESPX routes with request validation."""
+
+from collections.abc import Callable, Iterator
+from email import policy
+from email.parser import BytesParser
+from urllib.parse import parse_qs
+
+import httpx
+import respx
+from openapi_mock import add_openapi_to_respx as add_response_routes
+
+_HTTP_METHODS = frozenset({"delete", "get", "patch", "post", "put"})
+_URLENCODED = "application/x-www-form-urlencoded"
+_MULTIPART = "multipart/form-data"
+
+type JSONValue = (
+    bool | int | float | str | list[JSONValue] | dict[str, JSONValue] | None
+)
+type JSONMapping = dict[str, JSONValue]
+
+
+def add_openapi_to_respx(
+    *,
+    mock_obj: respx.MockRouter | respx.Router,
+    spec: JSONMapping,
+    base_url: str,
+) -> None:
+    """Add response routes and validate requests with their OpenAPI
+    schemas.
+    """
+    initial_route_count = len(mock_obj.routes)
+    add_response_routes(mock_obj=mock_obj, spec=spec, base_url=base_url)
+    routes = list(mock_obj.routes)[initial_route_count:]
+
+    for route, operation in zip(
+        routes,
+        _operations(spec=spec),
+        strict=True,
+    ):
+        request_body_object = operation.get("requestBody")
+        if not isinstance(request_body_object, dict):
+            continue
+        request_body: JSONMapping = request_body_object
+        response = route.return_value
+        assert response is not None
+        route.mock(
+            side_effect=_request_validator(
+                spec=spec,
+                request_body=request_body,
+                response=response,
+            ),
+        )
+
+
+def _operations(*, spec: JSONMapping) -> Iterator[JSONMapping]:
+    """Yield operations in the order used by ``openapi-mock``."""
+    paths_object = spec.get("paths", {})
+    assert isinstance(paths_object, dict)
+    paths: JSONMapping = paths_object
+    for path_item_object in paths.values():
+        if not isinstance(path_item_object, dict):  # pragma: no cover
+            continue
+        path_item: JSONMapping = path_item_object
+        for method, operation in path_item.items():
+            if method.lower() not in _HTTP_METHODS:
+                continue
+            if isinstance(operation, dict):  # pragma: no branch
+                yield operation
+
+
+def _request_validator(
+    *,
+    spec: JSONMapping,
+    request_body: JSONMapping,
+    response: httpx.Response,
+) -> Callable[[httpx.Request], httpx.Response]:
+    """Build a RESPX callback that validates one operation's request
+    body.
+    """
+
+    def validate_and_respond(request: httpx.Request) -> httpx.Response:
+        """Validate the request and return the configured response."""
+        _validate_request(
+            request=request,
+            request_body=request_body,
+            spec=spec,
+        )
+        return response
+
+    return validate_and_respond
+
+
+def _validate_request(
+    *,
+    request: httpx.Request,
+    request_body: JSONMapping,
+    spec: JSONMapping,
+) -> None:
+    """Validate an HTTPX request against an OpenAPI form request body."""
+    content_object = request_body.get("content", {})
+    assert isinstance(content_object, dict)
+    content: JSONMapping = content_object
+
+    if not request.content and not request_body.get("required", False):
+        return
+
+    content_type = request.headers.get(key="content-type", default="")
+    media_type = content_type.partition(";")[0].lower()
+    assert media_type in content, (
+        f"Unsupported content type {media_type or '<missing>'!r} for "
+        f"{request.method} {request.url.path}; expected one of "
+        f"{sorted(content)}"
+    )
+
+    media_definition_object = content[media_type]
+    assert isinstance(media_definition_object, dict)
+    media_definition: JSONMapping = media_definition_object
+    raw_schema = media_definition.get("schema", {})
+    assert isinstance(raw_schema, dict)
+    schema = _resolve_schema(spec=spec, raw_schema=raw_schema)
+    fields = _form_fields(
+        request=request,
+        media_type=media_type,
+        content_type=content_type,
+    )
+    properties_object = schema.get("properties", {})
+    assert isinstance(properties_object, dict)
+    properties: JSONMapping = properties_object
+    schema_required = schema.get("required", [])
+    raw_required = raw_schema.get("required", [])
+    assert isinstance(schema_required, list)
+    assert isinstance(raw_required, list)
+    schema_required_names = {
+        item for item in schema_required if isinstance(item, str)
+    }
+    raw_required_names = {
+        item for item in raw_required if isinstance(item, str)
+    }
+    assert len(schema_required_names) == len(schema_required)
+    assert len(raw_required_names) == len(raw_required)
+    required = schema_required_names | raw_required_names
+    missing = required - fields.keys()
+    assert not missing, (
+        f"Missing required form fields for {request.method} "
+        f"{request.url.path}: {sorted(missing)}"
+    )
+    if schema.get("additionalProperties", True) is False:
+        unexpected = fields.keys() - properties.keys()
+        assert not unexpected, (
+            f"Unexpected form fields for {request.method} "
+            f"{request.url.path}: {sorted(unexpected)}"
+        )
+    for name, value in fields.items():
+        property_object = properties.get(name)
+        if not isinstance(property_object, dict):
+            continue
+        property_schema: JSONMapping = property_object
+        if property_schema.get("format") == "binary":
+            assert isinstance(value, bytes), f"{name!r} must be a file"
+        else:
+            assert isinstance(value, str), f"{name!r} must be text"
+        allowed_values = property_schema.get("enum")
+        if allowed_values is not None:
+            assert isinstance(allowed_values, list)
+            assert value in allowed_values, (
+                f"Invalid value for form field {name!r}: {value!r}; "
+                f"expected one of {allowed_values}"
+            )
+
+
+def _resolve_schema(
+    *,
+    spec: JSONMapping,
+    raw_schema: JSONMapping,
+) -> JSONMapping:
+    """Resolve a local component schema reference."""
+    reference = raw_schema.get("$ref")
+    if reference is None:
+        return raw_schema
+    assert isinstance(reference, str)
+    prefix = "#/components/schemas/"
+    assert reference.startswith(prefix)
+    components_object = spec.get("components", {})
+    assert isinstance(components_object, dict)
+    components: JSONMapping = components_object
+    schemas_object = components.get("schemas", {})
+    assert isinstance(schemas_object, dict)
+    schemas: JSONMapping = schemas_object
+    schema_object = schemas[reference.removeprefix(prefix)]
+    assert isinstance(schema_object, dict)
+    schema: JSONMapping = schema_object
+    return schema
+
+
+def _form_fields(
+    *,
+    request: httpx.Request,
+    media_type: str,
+    content_type: str,
+) -> dict[str, str | bytes]:
+    """Decode URL-encoded or multipart form fields from a request."""
+    if media_type == _URLENCODED:
+        parsed = parse_qs(
+            qs=request.content.decode(),
+            keep_blank_values=True,
+            strict_parsing=True,
+        )
+        assert all(len(values) == 1 for values in parsed.values())
+        return {name: values[0] for name, values in parsed.items()}
+
+    assert media_type == _MULTIPART
+    message = BytesParser(policy=policy.default).parsebytes(
+        text=(
+            b"Content-Type: "
+            + content_type.encode()
+            + b"\r\nMIME-Version: 1.0\r\n\r\n"
+            + request.content
+        ),
+    )
+    assert message.is_multipart()
+    fields: dict[str, str | bytes] = {}
+    for part in message.iter_parts():
+        name = part.get_param(
+            param="name",
+            header="content-disposition",
+        )
+        assert isinstance(name, str)
+        assert name not in fields
+        payload = part.get_payload(decode=True)
+        assert isinstance(payload, bytes)
+        fields[name] = (
+            payload
+            if part.get_filename() is not None
+            else payload.decode(
+                encoding=part.get_content_charset() or "utf-8",
+            )
+        )
+    return fields

--- a/tests/test_openapi_mock.py
+++ b/tests/test_openapi_mock.py
@@ -1,0 +1,143 @@
+"""Tests for the request-validating OpenAPI mock."""
+
+import httpx
+import pytest
+import respx
+from respx.models import AllMockedAssertionError
+
+from tests.openapi_mock import JSONMapping, add_openapi_to_respx
+
+_QUESTIONS_URL = "https://app.coderpad.io/api/questions/"
+
+
+class TestOpenAPIRequestValidation:
+    """Tests for OpenAPI request-contract validation."""
+
+    @staticmethod
+    def test_supports_inline_extensible_schema() -> None:
+        """An inline schema may allow fields beyond declared
+        properties.
+        """
+        spec: JSONMapping = {
+            "paths": {
+                "/widgets/": {
+                    "post": {
+                        "requestBody": {
+                            "content": {
+                                "application/x-www-form-urlencoded": {
+                                    "schema": {"type": "object"},
+                                },
+                            },
+                        },
+                        "responses": {
+                            "200": {
+                                "content": {
+                                    "application/json": {
+                                        "example": {"status": "OK"},
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        }
+        with respx.mock(
+            base_url="https://example.com",
+            assert_all_called=False,
+        ) as mock_router:
+            add_openapi_to_respx(
+                mock_obj=mock_router,
+                spec=spec,
+                base_url="https://example.com",
+            )
+            response = httpx.post(
+                url="https://example.com/widgets/",
+                data={"extension": "value"},
+            )
+        assert response.json() == {"status": "OK"}
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        argnames=("method", "url"),
+        argvalues=[
+            ("PATCH", _QUESTIONS_URL),
+            ("POST", "https://app.coderpad.io/api/unknown/"),
+        ],
+    )
+    def test_rejects_unmatched_method_or_path(
+        mock_coderpad_api: object,
+        method: str,
+        url: str,
+    ) -> None:
+        """A method and path must match an OpenAPI operation."""
+        del mock_coderpad_api
+        with pytest.raises(expected_exception=AllMockedAssertionError):
+            httpx.request(method=method, url=url)
+
+    @staticmethod
+    def test_rejects_unsupported_content_type(
+        mock_coderpad_api: object,
+    ) -> None:
+        """The content type must be declared by the operation."""
+        del mock_coderpad_api
+        with pytest.raises(
+            expected_exception=AssertionError,
+            match="Unsupported content type 'application/json'",
+        ):
+            httpx.post(
+                url=_QUESTIONS_URL,
+                json={
+                    "question[title]": "FizzBuzz",
+                    "question[language]": "python",
+                },
+            )
+
+    @staticmethod
+    def test_rejects_missing_required_field(
+        mock_coderpad_api: object,
+    ) -> None:
+        """Required form fields must be present."""
+        del mock_coderpad_api
+        with pytest.raises(
+            expected_exception=AssertionError,
+            match=r"Missing required form fields.*question\[language\]",
+        ):
+            httpx.post(
+                url=_QUESTIONS_URL,
+                data={"question[title]": "FizzBuzz"},
+            )
+
+    @staticmethod
+    def test_rejects_unexpected_field(
+        mock_coderpad_api: object,
+    ) -> None:
+        """Form fields not declared by the schema are rejected."""
+        del mock_coderpad_api
+        with pytest.raises(
+            expected_exception=AssertionError,
+            match=r"Unexpected form fields.*question\[titel\]",
+        ):
+            httpx.post(
+                url=_QUESTIONS_URL,
+                data={
+                    "question[title]": "FizzBuzz",
+                    "question[language]": "python",
+                    "question[titel]": "misspelled",
+                },
+            )
+
+    @staticmethod
+    def test_rejects_invalid_field_value(
+        mock_coderpad_api: object,
+    ) -> None:
+        """A form value must satisfy its field schema."""
+        del mock_coderpad_api
+        with pytest.raises(
+            expected_exception=AssertionError,
+            match=r"Invalid value for form field 'ended'",
+        ):
+            httpx.put(
+                url="https://app.coderpad.io/api/pads/ABC1234",
+                data={"ended": "yes"},
+            )


### PR DESCRIPTION
Adds request-body schemas for pad and question create/update operations, covering URL-encoded forms and multipart ZIP uploads. Extends the RESPX OpenAPI fixture to validate methods, paths, content types, required and unexpected fields, file/text values, and enums while retaining explicit serialization tests. This closes #233 by catching generic request-contract drift that the previous response-only mock accepted. Validation: 180 tests pass with 100% branch coverage, and Ruff, MyPy, Pyright, Pyrefly, Ty, and the configured commit/push checks pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to test fixtures, OpenAPI metadata, and mock validation; production client code is unchanged aside from stricter test expectations.
> 
> **Overview**
> Extends the OpenAPI-backed test HTTP mock so **outgoing client requests** are checked against the bundled spec, not just mocked responses.
> 
> **`openapi.json`** now documents `requestBody` for pad create/update and question create/update (url-encoded and multipart), with new schemas `PadCreateForm`, `PadUpdateForm`, and `QuestionForm`.
> 
> **`tests/openapi_mock.py`** wraps the existing `openapi-mock` route setup and attaches validators that enforce declared content types, required fields, closed schemas (`additionalProperties: false`), enums, and text vs binary parts. Root and test **`conftest`** fixtures import this wrapper instead of calling `openapi_mock` directly.
> 
> **`tests/test_openapi_mock.py`** covers rejection of bad content types, missing/extra fields, and invalid enum values. A small **pyrefly** `search_path` tweak supports typing the new test module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67c0aa8cfd995e574be9f80725465ccf7f11d91b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->