### PR TITLE
Add no-defaults linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -269,6 +269,16 @@ repos:
         stages: [pre-commit]
         require_serial: true
 
+      - id: no-defaults
+        name: no-defaults
+        entry: uv run --extra=dev no-defaults
+        language: python
+        types_or: [python]
+        additional_dependencies:
+          - *uv_version
+        stages: [pre-commit]
+        require_serial: true
+
       - id: doc8
         name: doc8
         entry: uv run --extra=dev -m doc8
@@ -415,9 +425,3 @@ repos:
         types_or: [markdown, rst]
         additional_dependencies:
           - *uv_version
-
-  - repo: https://github.com/adamtheturtle/no-defaults
-    rev: v1.0.1
-    hooks:
-      - id: no-defaults
-        stages: [pre-commit]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -415,3 +415,9 @@ repos:
         types_or: [markdown, rst]
         additional_dependencies:
           - *uv_version
+
+  - repo: https://github.com/adamtheturtle/no-defaults
+    rev: v1.0.0
+    hooks:
+      - id: no-defaults
+        stages: [pre-commit]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -417,7 +417,7 @@ repos:
           - *uv_version
 
   - repo: https://github.com/adamtheturtle/no-defaults
-    rev: v1.0.0
+    rev: v1.0.1
     hooks:
       - id: no-defaults
         stages: [pre-commit]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ optional-dependencies.dev = [
     "interrogate==1.7.0",
     "mypy[faster-cache]==2.3.0",
     "mypy-strict-kwargs==2026.7.19.1",
+    "no-defaults==1.0.1",
     "openapi-mock==2026.3.2",
     "prek==0.4.11",
     "pydocstringformatter==1.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,6 +150,7 @@ lint.per-file-ignores."tests/*.py" = [
 lint.unfixable = [
     "ERA001",
 ]
+lint.external = [ "NOD" ]
 lint.flake8-tidy-imports.banned-api."typing.cast".msg = "typing.cast is banned: use explicit type narrowing or a typed variable instead."
 lint.pydocstyle.convention = "google"
 
@@ -498,3 +499,7 @@ ignore_path = [
 [tool.yamlfix]
 section_whitelines = 1
 whitelines = 1
+
+[tool.no_defaults]
+private_only = true
+per_file_enforcement."tests/**" = "all"

--- a/src/coderpad/async_client.py
+++ b/src/coderpad/async_client.py
@@ -63,9 +63,9 @@ class _AsyncNamespace:
         *,
         method: str,
         url: str,
-        params: dict[str, str | int] | None = None,
-        data: dict[str, str] | None = None,
-        files: (dict[str, tuple[str, bytes, str]] | None) = None,
+        params: dict[str, str | int] | None = None,  # noqa: NOD001
+        data: dict[str, str] | None = None,  # noqa: NOD001
+        files: (dict[str, tuple[str, bytes, str]] | None) = None,  # noqa: NOD001
     ) -> TransportResponse:
         """Make an async HTTP request.
 

--- a/src/coderpad/async_screen.py
+++ b/src/coderpad/async_screen.py
@@ -29,7 +29,7 @@ class _AsyncScreenNamespace:
         *,
         transport: AsyncJSONTransport,
         api_key: str,
-        base_url: str = SCREEN_US_BASE_URL,
+        base_url: str = SCREEN_US_BASE_URL,  # noqa: NOD001
     ) -> None:
         """Create shared asynchronous Screen request state."""
         self.transport: AsyncJSONTransport = transport
@@ -41,8 +41,8 @@ class _AsyncScreenNamespace:
         *,
         method: str,
         path: str,
-        params: dict[str, str | int] | None = None,
-        json: object | None = None,
+        params: dict[str, str | int] | None = None,  # noqa: NOD001
+        json: object | None = None,  # noqa: NOD001
     ) -> TransportResponse:
         """Make a Screen request and map HTTP failures."""
         response = await self.transport(

--- a/src/coderpad/client.py
+++ b/src/coderpad/client.py
@@ -62,9 +62,9 @@ class _Namespace:
         *,
         method: str,
         url: str,
-        params: dict[str, str | int] | None = None,
-        data: dict[str, str] | None = None,
-        files: (dict[str, tuple[str, bytes, str]] | None) = None,
+        params: dict[str, str | int] | None = None,  # noqa: NOD001
+        data: dict[str, str] | None = None,  # noqa: NOD001
+        files: (dict[str, tuple[str, bytes, str]] | None) = None,  # noqa: NOD001
     ) -> TransportResponse:
         """Make an HTTP request.
 

--- a/src/coderpad/screen.py
+++ b/src/coderpad/screen.py
@@ -42,8 +42,8 @@ class _ScreenNamespace:
         *,
         method: str,
         path: str,
-        params: dict[str, str | int] | None = None,
-        json: object | None = None,
+        params: dict[str, str | int] | None = None,  # noqa: NOD001
+        json: object | None = None,  # noqa: NOD001
     ) -> TransportResponse:
         """Make a Screen request and map HTTP failures."""
         response = self.transport(

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -97,9 +97,9 @@ class TestAsyncCoderPad:
                 method: str,
                 url: str,
                 headers: dict[str, str],
-                params: (dict[str, str | int] | None) = None,
-                data: dict[str, str] | None = None,
-                files: (dict[str, tuple[str, bytes, str]] | None) = None,
+                params: (dict[str, str | int] | None) = None,  # noqa: NOD001
+                data: dict[str, str] | None = None,  # noqa: NOD001
+                files: (dict[str, tuple[str, bytes, str]] | None) = None,  # noqa: NOD001
             ) -> TransportResponse:  # pragma: no cover
                 """Make a request."""
                 raise NotImplementedError
@@ -352,9 +352,9 @@ class TestAsyncGetPadEnvironment:
             method: str,
             url: str,
             headers: dict[str, str],
-            params: dict[str, str | int] | None = None,
-            data: dict[str, str] | None = None,
-            files: (dict[str, tuple[str, bytes, str]] | None) = None,
+            params: dict[str, str | int] | None = None,  # noqa: NOD001
+            data: dict[str, str] | None = None,  # noqa: NOD001
+            files: (dict[str, tuple[str, bytes, str]] | None) = None,  # noqa: NOD001
         ) -> TransportResponse:
             """Return synthetic live-response variants."""
             del headers, params, data, files
@@ -399,9 +399,9 @@ class TestAsyncGetPadHistory:
             method: str,
             url: str,
             headers: dict[str, str],
-            params: (dict[str, str | int] | None) = None,
-            data: dict[str, str] | None = None,
-            files: (dict[str, tuple[str, bytes, str]] | None) = None,
+            params: (dict[str, str | int] | None) = None,  # noqa: NOD001
+            data: dict[str, str] | None = None,  # noqa: NOD001
+            files: (dict[str, tuple[str, bytes, str]] | None) = None,  # noqa: NOD001
         ) -> TransportResponse:
             """Return sample Firebase history."""
             del params, data, files
@@ -439,9 +439,9 @@ class TestAsyncGetPadHistory:
             method: str,
             url: str,
             headers: dict[str, str],
-            params: (dict[str, str | int] | None) = None,
-            data: dict[str, str] | None = None,
-            files: (dict[str, tuple[str, bytes, str]] | None) = None,
+            params: (dict[str, str | int] | None) = None,  # noqa: NOD001
+            data: dict[str, str] | None = None,  # noqa: NOD001
+            files: (dict[str, tuple[str, bytes, str]] | None) = None,  # noqa: NOD001
         ) -> TransportResponse:
             """Return an empty Firebase history."""
             del method, url, headers, params, data, files
@@ -470,9 +470,9 @@ class TestAsyncGetPadHistory:
             method: str,
             url: str,
             headers: dict[str, str],
-            params: (dict[str, str | int] | None) = None,
-            data: dict[str, str] | None = None,
-            files: (dict[str, tuple[str, bytes, str]] | None) = None,
+            params: (dict[str, str | int] | None) = None,  # noqa: NOD001
+            data: dict[str, str] | None = None,  # noqa: NOD001
+            files: (dict[str, tuple[str, bytes, str]] | None) = None,  # noqa: NOD001
         ) -> TransportResponse:
             """Return a missing history response."""
             del method, url, headers, params, data, files
@@ -939,9 +939,9 @@ class TestAsyncListOrganizationUsers:
             method: str,
             url: str,
             headers: dict[str, str],
-            params: (dict[str, str | int] | None) = None,
-            data: dict[str, str] | None = None,
-            files: (dict[str, tuple[str, bytes, str]] | None) = None,
+            params: (dict[str, str | int] | None) = None,  # noqa: NOD001
+            data: dict[str, str] | None = None,  # noqa: NOD001
+            files: (dict[str, tuple[str, bytes, str]] | None) = None,  # noqa: NOD001
         ) -> TransportResponse:
             """Return an empty successful user response."""
             del method, url, headers, params, data, files
@@ -966,9 +966,9 @@ class TestAsyncListOrganizationUsers:
             method: str,
             url: str,
             headers: dict[str, str],
-            params: (dict[str, str | int] | None) = None,
-            data: dict[str, str] | None = None,
-            files: (dict[str, tuple[str, bytes, str]] | None) = None,
+            params: (dict[str, str | int] | None) = None,  # noqa: NOD001
+            data: dict[str, str] | None = None,  # noqa: NOD001
+            files: (dict[str, tuple[str, bytes, str]] | None) = None,  # noqa: NOD001
         ) -> TransportResponse:
             """Return a not-found user response."""
             del method, url, headers, params, data, files
@@ -996,9 +996,9 @@ class TestAsyncExceptionHandling:
             method: str,
             url: str,
             headers: dict[str, str],
-            params: (dict[str, str | int] | None) = None,
-            data: dict[str, str] | None = None,
-            files: (dict[str, tuple[str, bytes, str]] | None) = None,
+            params: (dict[str, str | int] | None) = None,  # noqa: NOD001
+            data: dict[str, str] | None = None,  # noqa: NOD001
+            files: (dict[str, tuple[str, bytes, str]] | None) = None,  # noqa: NOD001
         ) -> TransportResponse:
             """Return a 404 response."""
             del method, url, headers, params, data, files

--- a/tests/test_async_screen.py
+++ b/tests/test_async_screen.py
@@ -16,7 +16,7 @@ from coderpad.transports import TransportResponse
 class _AsyncScreenTransport:
     """Record asynchronous Screen requests."""
 
-    def __init__(self, *, error: bool = False) -> None:
+    def __init__(self, *, error: bool = False) -> None:  # noqa: NOD001
         """Create a recording transport."""
         self.calls: list[dict[str, object]] = []
         self.error = error
@@ -27,10 +27,10 @@ class _AsyncScreenTransport:
         method: str,
         url: str,
         headers: dict[str, str],
-        params: dict[str, str | int] | None = None,
-        data: dict[str, str] | None = None,
-        files: dict[str, tuple[str, bytes, str]] | None = None,
-        json: object | None = None,
+        params: dict[str, str | int] | None = None,  # noqa: NOD001
+        data: dict[str, str] | None = None,  # noqa: NOD001
+        files: dict[str, tuple[str, bytes, str]] | None = None,  # noqa: NOD001
+        json: object | None = None,  # noqa: NOD001
     ) -> TransportResponse:
         """Return a response selected by the request path."""
         del data, files
@@ -92,7 +92,7 @@ def _response(
     value: object,
     /,
     *,
-    status: HTTPStatus = HTTPStatus.OK,
+    status: HTTPStatus = HTTPStatus.OK,  # noqa: NOD001
 ) -> TransportResponse:
     """Create a JSON transport response."""
     return TransportResponse(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -99,9 +99,9 @@ class TestCoderPad:
                 method: str,
                 url: str,
                 headers: dict[str, str],
-                params: dict[str, str | int] | None = None,
-                data: dict[str, str] | None = None,
-                files: (dict[str, tuple[str, bytes, str]] | None) = None,
+                params: dict[str, str | int] | None = None,  # noqa: NOD001
+                data: dict[str, str] | None = None,  # noqa: NOD001
+                files: (dict[str, tuple[str, bytes, str]] | None) = None,  # noqa: NOD001
             ) -> TransportResponse:  # pragma: no cover
                 """Make a request."""
                 raise NotImplementedError
@@ -338,9 +338,9 @@ class TestExceptionHierarchy:
             method: str,
             url: str,
             headers: dict[str, str],
-            params: dict[str, str | int] | None = None,
-            data: dict[str, str] | None = None,
-            files: (dict[str, tuple[str, bytes, str]] | None) = None,
+            params: dict[str, str | int] | None = None,  # noqa: NOD001
+            data: dict[str, str] | None = None,  # noqa: NOD001
+            files: (dict[str, tuple[str, bytes, str]] | None) = None,  # noqa: NOD001
         ) -> TransportResponse:
             """Return a 404 response."""
             del method, url, headers, params, data, files
@@ -552,9 +552,9 @@ class TestGetPadEnvironment:
             method: str,
             url: str,
             headers: dict[str, str],
-            params: dict[str, str | int] | None = None,
-            data: dict[str, str] | None = None,
-            files: (dict[str, tuple[str, bytes, str]] | None) = None,
+            params: dict[str, str | int] | None = None,  # noqa: NOD001
+            data: dict[str, str] | None = None,  # noqa: NOD001
+            files: (dict[str, tuple[str, bytes, str]] | None) = None,  # noqa: NOD001
         ) -> TransportResponse:
             """Return synthetic live-response variants."""
             del headers, params, data, files
@@ -595,9 +595,9 @@ class TestGetPadHistory:
             method: str,
             url: str,
             headers: dict[str, str],
-            params: dict[str, str | int] | None = None,
-            data: dict[str, str] | None = None,
-            files: (dict[str, tuple[str, bytes, str]] | None) = None,
+            params: dict[str, str | int] | None = None,  # noqa: NOD001
+            data: dict[str, str] | None = None,  # noqa: NOD001
+            files: (dict[str, tuple[str, bytes, str]] | None) = None,  # noqa: NOD001
         ) -> TransportResponse:
             """Return sample Firebase history."""
             del params, data, files
@@ -634,9 +634,9 @@ class TestGetPadHistory:
             method: str,
             url: str,
             headers: dict[str, str],
-            params: dict[str, str | int] | None = None,
-            data: dict[str, str] | None = None,
-            files: (dict[str, tuple[str, bytes, str]] | None) = None,
+            params: dict[str, str | int] | None = None,  # noqa: NOD001
+            data: dict[str, str] | None = None,  # noqa: NOD001
+            files: (dict[str, tuple[str, bytes, str]] | None) = None,  # noqa: NOD001
         ) -> TransportResponse:
             """Return an empty Firebase history."""
             del method, url, headers, params, data, files
@@ -664,9 +664,9 @@ class TestGetPadHistory:
             method: str,
             url: str,
             headers: dict[str, str],
-            params: dict[str, str | int] | None = None,
-            data: dict[str, str] | None = None,
-            files: (dict[str, tuple[str, bytes, str]] | None) = None,
+            params: dict[str, str | int] | None = None,  # noqa: NOD001
+            data: dict[str, str] | None = None,  # noqa: NOD001
+            files: (dict[str, tuple[str, bytes, str]] | None) = None,  # noqa: NOD001
         ) -> TransportResponse:
             """Return a missing history response."""
             del method, url, headers, params, data, files
@@ -1103,9 +1103,9 @@ class TestListOrganizationUsers:
             method: str,
             url: str,
             headers: dict[str, str],
-            params: dict[str, str | int] | None = None,
-            data: dict[str, str] | None = None,
-            files: (dict[str, tuple[str, bytes, str]] | None) = None,
+            params: dict[str, str | int] | None = None,  # noqa: NOD001
+            data: dict[str, str] | None = None,  # noqa: NOD001
+            files: (dict[str, tuple[str, bytes, str]] | None) = None,  # noqa: NOD001
         ) -> TransportResponse:
             """Return an empty successful user response."""
             del method, url, headers, params, data, files
@@ -1129,9 +1129,9 @@ class TestListOrganizationUsers:
             method: str,
             url: str,
             headers: dict[str, str],
-            params: dict[str, str | int] | None = None,
-            data: dict[str, str] | None = None,
-            files: (dict[str, tuple[str, bytes, str]] | None) = None,
+            params: dict[str, str | int] | None = None,  # noqa: NOD001
+            data: dict[str, str] | None = None,  # noqa: NOD001
+            files: (dict[str, tuple[str, bytes, str]] | None) = None,  # noqa: NOD001
         ) -> TransportResponse:
             """Return a not-found user response."""
             del method, url, headers, params, data, files

--- a/tests/test_screen.py
+++ b/tests/test_screen.py
@@ -48,7 +48,7 @@ _TEST = {
 class ScreenTransportStub:
     """Record requests and return representative Screen responses."""
 
-    def __init__(self, *, error: bool = False) -> None:
+    def __init__(self, *, error: bool = False) -> None:  # noqa: NOD001
         """Create a recording transport."""
         self.calls: list[dict[str, object]] = []
         self.error = error
@@ -59,10 +59,10 @@ class ScreenTransportStub:
         method: str,
         url: str,
         headers: dict[str, str],
-        params: dict[str, str | int] | None = None,
-        data: dict[str, str] | None = None,
-        files: dict[str, tuple[str, bytes, str]] | None = None,
-        json: object | None = None,
+        params: dict[str, str | int] | None = None,  # noqa: NOD001
+        data: dict[str, str] | None = None,  # noqa: NOD001
+        files: dict[str, tuple[str, bytes, str]] | None = None,  # noqa: NOD001
+        json: object | None = None,  # noqa: NOD001
     ) -> TransportResponse:
         """Return a response selected by the request path."""
         del data, files
@@ -126,7 +126,7 @@ def _response(
     value: object,
     /,
     *,
-    status: HTTPStatus = HTTPStatus.OK,
+    status: HTTPStatus = HTTPStatus.OK,  # noqa: NOD001
 ) -> TransportResponse:
     """Create a JSON transport response."""
     return TransportResponse(
@@ -140,7 +140,7 @@ def _client(
     transport: ScreenTransportStub,
     /,
     *,
-    base_url: str = SCREEN_EU_BASE_URL,
+    base_url: str = SCREEN_EU_BASE_URL,  # noqa: NOD001
 ) -> CoderPad:
     """Create a client using the recording transport."""
     return CoderPad(


### PR DESCRIPTION
Add `no-defaults` v1.0.0 to the pre-commit/prek configuration.

The policy rejects defaults everywhere in `tests/**` and for private functions, classes, and modules elsewhere. Existing defaults are behavior-preservingly baselined with targeted `# noqa: NOD001` comments where necessary; Ruff is configured to recognize the external `NOD` rule family. Vendored Typeshed is excluded where applicable.

Validated with `prek validate-config`, `prek run no-defaults --all-files`, and Ruff checks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint and tooling only; runtime behavior is unchanged aside from noqa comments on existing signatures.
> 
> **Overview**
> Adds **`no-defaults`** (v1.0.1) to dev dependencies and wires a **pre-commit** hook that runs it on Python files, alongside existing tooling like `strict-kwargs`.
> 
> Policy is configured in **`[tool.no_defaults]`**: **`private_only`** for library code and **`all`** defaults disallowed under **`tests/**`**. Ruff is updated with **`lint.external = ["NOD"]`** so **`# noqa: NOD001`** suppressions are recognized.
> 
> Existing default arguments are **baselined** with targeted **`# noqa: NOD001`** on private `_request` helpers in sync/async client and Screen modules, plus matching stubs in tests—**no API or runtime behavior changes**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e85560e2a03cdc218c0edb0cd6ade696d9d91a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->