### PR TITLE
Remove the test defaults instead of suppressing them

### DIFF
--- a/src/coderpad/async_screen.py
+++ b/src/coderpad/async_screen.py
@@ -50,6 +50,8 @@ class _AsyncScreenNamespace:
             url=self.base_url + _SCREEN_PREFIX + path,
             headers=self.headers,
             params=params,
+            data=None,
+            files=None,
             json=json,
         )
         if response.status_code >= HTTPStatus.BAD_REQUEST:

--- a/src/coderpad/screen.py
+++ b/src/coderpad/screen.py
@@ -51,6 +51,8 @@ class _ScreenNamespace:
             url=self.base_url + _SCREEN_PREFIX + path,
             headers=self.headers,
             params=params,
+            data=None,
+            files=None,
             json=json,
         )
         if response.status_code >= HTTPStatus.BAD_REQUEST:

--- a/src/coderpad/transports.py
+++ b/src/coderpad/transports.py
@@ -74,9 +74,9 @@ class Transport(Protocol):
         method: str,
         url: str,
         headers: dict[str, str],
-        params: dict[str, str | int] | None = None,
-        data: dict[str, str] | None = None,
-        files: (dict[str, tuple[str, bytes, str]] | None) = None,
+        params: dict[str, str | int] | None,
+        data: dict[str, str] | None,
+        files: (dict[str, tuple[str, bytes, str]] | None),
     ) -> TransportResponse:
         """Make an HTTP request.
 
@@ -107,10 +107,10 @@ class JSONTransport(Protocol):
         method: str,
         url: str,
         headers: dict[str, str],
-        params: dict[str, str | int] | None = None,
-        data: dict[str, str] | None = None,
-        files: (dict[str, tuple[str, bytes, str]] | None) = None,
-        json: object | None = None,
+        params: dict[str, str | int] | None,
+        data: dict[str, str] | None,
+        files: (dict[str, tuple[str, bytes, str]] | None),
+        json: object | None,
     ) -> TransportResponse:
         """Make an HTTP request with an optional JSON body."""
         ...  # pylint: disable=unnecessary-ellipsis
@@ -155,9 +155,9 @@ class HTTPXTransport:
         method: str,
         url: str,
         headers: dict[str, str],
-        params: dict[str, str | int] | None = None,
-        data: dict[str, str] | None = None,
-        files: (dict[str, tuple[str, bytes, str]] | None) = None,
+        params: dict[str, str | int] | None,
+        data: dict[str, str] | None,
+        files: (dict[str, tuple[str, bytes, str]] | None),
         json: object | None = None,
     ) -> TransportResponse:
         """Make an HTTP request using ``httpx``.
@@ -205,9 +205,9 @@ class AsyncTransport(Protocol):
         method: str,
         url: str,
         headers: dict[str, str],
-        params: dict[str, str | int] | None = None,
-        data: dict[str, str] | None = None,
-        files: (dict[str, tuple[str, bytes, str]] | None) = None,
+        params: dict[str, str | int] | None,
+        data: dict[str, str] | None,
+        files: (dict[str, tuple[str, bytes, str]] | None),
     ) -> TransportResponse:
         """Make an async HTTP request.
 
@@ -238,10 +238,10 @@ class AsyncJSONTransport(Protocol):
         method: str,
         url: str,
         headers: dict[str, str],
-        params: dict[str, str | int] | None = None,
-        data: dict[str, str] | None = None,
-        files: (dict[str, tuple[str, bytes, str]] | None) = None,
-        json: object | None = None,
+        params: dict[str, str | int] | None,
+        data: dict[str, str] | None,
+        files: (dict[str, tuple[str, bytes, str]] | None),
+        json: object | None,
     ) -> TransportResponse:
         """Make an async HTTP request with an optional JSON body."""
         ...  # pylint: disable=unnecessary-ellipsis
@@ -287,9 +287,9 @@ class AsyncHTTPXTransport:
         method: str,
         url: str,
         headers: dict[str, str],
-        params: dict[str, str | int] | None = None,
-        data: dict[str, str] | None = None,
-        files: (dict[str, tuple[str, bytes, str]] | None) = None,
+        params: dict[str, str | int] | None,
+        data: dict[str, str] | None,
+        files: (dict[str, tuple[str, bytes, str]] | None),
         json: object | None = None,
     ) -> TransportResponse:
         """Make an async HTTP request using ``httpx``.

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -97,9 +97,9 @@ class TestAsyncCoderPad:
                 method: str,
                 url: str,
                 headers: dict[str, str],
-                params: (dict[str, str | int] | None) = None,  # noqa: NOD001
-                data: dict[str, str] | None = None,  # noqa: NOD001
-                files: (dict[str, tuple[str, bytes, str]] | None) = None,  # noqa: NOD001
+                params: (dict[str, str | int] | None),
+                data: dict[str, str] | None,
+                files: (dict[str, tuple[str, bytes, str]] | None),
             ) -> TransportResponse:  # pragma: no cover
                 """Make a request."""
                 raise NotImplementedError
@@ -352,9 +352,9 @@ class TestAsyncGetPadEnvironment:
             method: str,
             url: str,
             headers: dict[str, str],
-            params: dict[str, str | int] | None = None,  # noqa: NOD001
-            data: dict[str, str] | None = None,  # noqa: NOD001
-            files: (dict[str, tuple[str, bytes, str]] | None) = None,  # noqa: NOD001
+            params: dict[str, str | int] | None,
+            data: dict[str, str] | None,
+            files: (dict[str, tuple[str, bytes, str]] | None),
         ) -> TransportResponse:
             """Return synthetic live-response variants."""
             del headers, params, data, files
@@ -399,9 +399,9 @@ class TestAsyncGetPadHistory:
             method: str,
             url: str,
             headers: dict[str, str],
-            params: (dict[str, str | int] | None) = None,  # noqa: NOD001
-            data: dict[str, str] | None = None,  # noqa: NOD001
-            files: (dict[str, tuple[str, bytes, str]] | None) = None,  # noqa: NOD001
+            params: (dict[str, str | int] | None),
+            data: dict[str, str] | None,
+            files: (dict[str, tuple[str, bytes, str]] | None),
         ) -> TransportResponse:
             """Return sample Firebase history."""
             del params, data, files
@@ -439,9 +439,9 @@ class TestAsyncGetPadHistory:
             method: str,
             url: str,
             headers: dict[str, str],
-            params: (dict[str, str | int] | None) = None,  # noqa: NOD001
-            data: dict[str, str] | None = None,  # noqa: NOD001
-            files: (dict[str, tuple[str, bytes, str]] | None) = None,  # noqa: NOD001
+            params: (dict[str, str | int] | None),
+            data: dict[str, str] | None,
+            files: (dict[str, tuple[str, bytes, str]] | None),
         ) -> TransportResponse:
             """Return an empty Firebase history."""
             del method, url, headers, params, data, files
@@ -470,9 +470,9 @@ class TestAsyncGetPadHistory:
             method: str,
             url: str,
             headers: dict[str, str],
-            params: (dict[str, str | int] | None) = None,  # noqa: NOD001
-            data: dict[str, str] | None = None,  # noqa: NOD001
-            files: (dict[str, tuple[str, bytes, str]] | None) = None,  # noqa: NOD001
+            params: (dict[str, str | int] | None),
+            data: dict[str, str] | None,
+            files: (dict[str, tuple[str, bytes, str]] | None),
         ) -> TransportResponse:
             """Return a missing history response."""
             del method, url, headers, params, data, files
@@ -939,9 +939,9 @@ class TestAsyncListOrganizationUsers:
             method: str,
             url: str,
             headers: dict[str, str],
-            params: (dict[str, str | int] | None) = None,  # noqa: NOD001
-            data: dict[str, str] | None = None,  # noqa: NOD001
-            files: (dict[str, tuple[str, bytes, str]] | None) = None,  # noqa: NOD001
+            params: (dict[str, str | int] | None),
+            data: dict[str, str] | None,
+            files: (dict[str, tuple[str, bytes, str]] | None),
         ) -> TransportResponse:
             """Return an empty successful user response."""
             del method, url, headers, params, data, files
@@ -966,9 +966,9 @@ class TestAsyncListOrganizationUsers:
             method: str,
             url: str,
             headers: dict[str, str],
-            params: (dict[str, str | int] | None) = None,  # noqa: NOD001
-            data: dict[str, str] | None = None,  # noqa: NOD001
-            files: (dict[str, tuple[str, bytes, str]] | None) = None,  # noqa: NOD001
+            params: (dict[str, str | int] | None),
+            data: dict[str, str] | None,
+            files: (dict[str, tuple[str, bytes, str]] | None),
         ) -> TransportResponse:
             """Return a not-found user response."""
             del method, url, headers, params, data, files
@@ -996,9 +996,9 @@ class TestAsyncExceptionHandling:
             method: str,
             url: str,
             headers: dict[str, str],
-            params: (dict[str, str | int] | None) = None,  # noqa: NOD001
-            data: dict[str, str] | None = None,  # noqa: NOD001
-            files: (dict[str, tuple[str, bytes, str]] | None) = None,  # noqa: NOD001
+            params: (dict[str, str | int] | None),
+            data: dict[str, str] | None,
+            files: (dict[str, tuple[str, bytes, str]] | None),
         ) -> TransportResponse:
             """Return a 404 response."""
             del method, url, headers, params, data, files

--- a/tests/test_async_screen.py
+++ b/tests/test_async_screen.py
@@ -16,7 +16,7 @@ from coderpad.transports import TransportResponse
 class _AsyncScreenTransport:
     """Record asynchronous Screen requests."""
 
-    def __init__(self, *, error: bool = False) -> None:  # noqa: NOD001
+    def __init__(self, *, error: bool) -> None:
         """Create a recording transport."""
         self.calls: list[dict[str, object]] = []
         self.error = error
@@ -27,10 +27,10 @@ class _AsyncScreenTransport:
         method: str,
         url: str,
         headers: dict[str, str],
-        params: dict[str, str | int] | None = None,  # noqa: NOD001
-        data: dict[str, str] | None = None,  # noqa: NOD001
-        files: dict[str, tuple[str, bytes, str]] | None = None,  # noqa: NOD001
-        json: object | None = None,  # noqa: NOD001
+        params: dict[str, str | int] | None,
+        data: dict[str, str] | None,
+        files: dict[str, tuple[str, bytes, str]] | None,
+        json: object | None,
     ) -> TransportResponse:
         """Return a response selected by the request path."""
         del data, files
@@ -49,9 +49,14 @@ class _AsyncScreenTransport:
                 status=HTTPStatus.UNAUTHORIZED,
             )
         if url.endswith("/campaigns"):
-            return _response([{"id": 7, "name": "Backend"}])
+            return _response(
+                [{"id": 7, "name": "Backend"}], status=HTTPStatus.OK
+            )
         if url.endswith("/campaigns/7/actions/send"):
-            return _response({"id": 11, "test_url": "https://test.example"})
+            return _response(
+                {"id": 11, "test_url": "https://test.example"},
+                status=HTTPStatus.OK,
+            )
         if url.endswith("/tests"):
             return _response(
                 {
@@ -64,6 +69,7 @@ class _AsyncScreenTransport:
                     ],
                     "pagination": {"total": 2},
                 },
+                status=HTTPStatus.OK,
             )
         if url.endswith("/tests/11/report"):
             return TransportResponse(
@@ -78,9 +84,12 @@ class _AsyncScreenTransport:
                     "status": "completed",
                     "report": dict[str, object](),
                 },
+                status=HTTPStatus.OK,
             )
         if url.endswith("/webhook") and method == "GET":
-            return _response({"url": "https://example.com/hook"})
+            return _response(
+                {"url": "https://example.com/hook"}, status=HTTPStatus.OK
+            )
         return TransportResponse(
             status_code=HTTPStatus.NO_CONTENT,
             headers={},
@@ -92,7 +101,7 @@ def _response(
     value: object,
     /,
     *,
-    status: HTTPStatus = HTTPStatus.OK,  # noqa: NOD001
+    status: HTTPStatus,
 ) -> TransportResponse:
     """Create a JSON transport response."""
     return TransportResponse(
@@ -114,7 +123,7 @@ def _client(transport: _AsyncScreenTransport, /) -> AsyncCoderPad:
 @pytest.mark.asyncio
 async def test_async_screen_matches_sync_surface() -> None:
     """The asynchronous namespaces expose equivalent operations."""
-    recorder = _AsyncScreenTransport()
+    recorder = _AsyncScreenTransport(error=False)
     client = _client(recorder)
     screen = client.screen
     campaigns = await screen.campaigns.list()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -99,9 +99,9 @@ class TestCoderPad:
                 method: str,
                 url: str,
                 headers: dict[str, str],
-                params: dict[str, str | int] | None = None,  # noqa: NOD001
-                data: dict[str, str] | None = None,  # noqa: NOD001
-                files: (dict[str, tuple[str, bytes, str]] | None) = None,  # noqa: NOD001
+                params: dict[str, str | int] | None,
+                data: dict[str, str] | None,
+                files: (dict[str, tuple[str, bytes, str]] | None),
             ) -> TransportResponse:  # pragma: no cover
                 """Make a request."""
                 raise NotImplementedError
@@ -338,9 +338,9 @@ class TestExceptionHierarchy:
             method: str,
             url: str,
             headers: dict[str, str],
-            params: dict[str, str | int] | None = None,  # noqa: NOD001
-            data: dict[str, str] | None = None,  # noqa: NOD001
-            files: (dict[str, tuple[str, bytes, str]] | None) = None,  # noqa: NOD001
+            params: dict[str, str | int] | None,
+            data: dict[str, str] | None,
+            files: (dict[str, tuple[str, bytes, str]] | None),
         ) -> TransportResponse:
             """Return a 404 response."""
             del method, url, headers, params, data, files
@@ -552,9 +552,9 @@ class TestGetPadEnvironment:
             method: str,
             url: str,
             headers: dict[str, str],
-            params: dict[str, str | int] | None = None,  # noqa: NOD001
-            data: dict[str, str] | None = None,  # noqa: NOD001
-            files: (dict[str, tuple[str, bytes, str]] | None) = None,  # noqa: NOD001
+            params: dict[str, str | int] | None,
+            data: dict[str, str] | None,
+            files: (dict[str, tuple[str, bytes, str]] | None),
         ) -> TransportResponse:
             """Return synthetic live-response variants."""
             del headers, params, data, files
@@ -595,9 +595,9 @@ class TestGetPadHistory:
             method: str,
             url: str,
             headers: dict[str, str],
-            params: dict[str, str | int] | None = None,  # noqa: NOD001
-            data: dict[str, str] | None = None,  # noqa: NOD001
-            files: (dict[str, tuple[str, bytes, str]] | None) = None,  # noqa: NOD001
+            params: dict[str, str | int] | None,
+            data: dict[str, str] | None,
+            files: (dict[str, tuple[str, bytes, str]] | None),
         ) -> TransportResponse:
             """Return sample Firebase history."""
             del params, data, files
@@ -634,9 +634,9 @@ class TestGetPadHistory:
             method: str,
             url: str,
             headers: dict[str, str],
-            params: dict[str, str | int] | None = None,  # noqa: NOD001
-            data: dict[str, str] | None = None,  # noqa: NOD001
-            files: (dict[str, tuple[str, bytes, str]] | None) = None,  # noqa: NOD001
+            params: dict[str, str | int] | None,
+            data: dict[str, str] | None,
+            files: (dict[str, tuple[str, bytes, str]] | None),
         ) -> TransportResponse:
             """Return an empty Firebase history."""
             del method, url, headers, params, data, files
@@ -664,9 +664,9 @@ class TestGetPadHistory:
             method: str,
             url: str,
             headers: dict[str, str],
-            params: dict[str, str | int] | None = None,  # noqa: NOD001
-            data: dict[str, str] | None = None,  # noqa: NOD001
-            files: (dict[str, tuple[str, bytes, str]] | None) = None,  # noqa: NOD001
+            params: dict[str, str | int] | None,
+            data: dict[str, str] | None,
+            files: (dict[str, tuple[str, bytes, str]] | None),
         ) -> TransportResponse:
             """Return a missing history response."""
             del method, url, headers, params, data, files
@@ -1103,9 +1103,9 @@ class TestListOrganizationUsers:
             method: str,
             url: str,
             headers: dict[str, str],
-            params: dict[str, str | int] | None = None,  # noqa: NOD001
-            data: dict[str, str] | None = None,  # noqa: NOD001
-            files: (dict[str, tuple[str, bytes, str]] | None) = None,  # noqa: NOD001
+            params: dict[str, str | int] | None,
+            data: dict[str, str] | None,
+            files: (dict[str, tuple[str, bytes, str]] | None),
         ) -> TransportResponse:
             """Return an empty successful user response."""
             del method, url, headers, params, data, files
@@ -1129,9 +1129,9 @@ class TestListOrganizationUsers:
             method: str,
             url: str,
             headers: dict[str, str],
-            params: dict[str, str | int] | None = None,  # noqa: NOD001
-            data: dict[str, str] | None = None,  # noqa: NOD001
-            files: (dict[str, tuple[str, bytes, str]] | None) = None,  # noqa: NOD001
+            params: dict[str, str | int] | None,
+            data: dict[str, str] | None,
+            files: (dict[str, tuple[str, bytes, str]] | None),
         ) -> TransportResponse:
             """Return a not-found user response."""
             del method, url, headers, params, data, files

--- a/tests/test_screen.py
+++ b/tests/test_screen.py
@@ -48,7 +48,7 @@ _TEST = {
 class ScreenTransportStub:
     """Record requests and return representative Screen responses."""
 
-    def __init__(self, *, error: bool = False) -> None:  # noqa: NOD001
+    def __init__(self, *, error: bool) -> None:
         """Create a recording transport."""
         self.calls: list[dict[str, object]] = []
         self.error = error
@@ -59,10 +59,10 @@ class ScreenTransportStub:
         method: str,
         url: str,
         headers: dict[str, str],
-        params: dict[str, str | int] | None = None,  # noqa: NOD001
-        data: dict[str, str] | None = None,  # noqa: NOD001
-        files: dict[str, tuple[str, bytes, str]] | None = None,  # noqa: NOD001
-        json: object | None = None,  # noqa: NOD001
+        params: dict[str, str | int] | None,
+        data: dict[str, str] | None,
+        files: dict[str, tuple[str, bytes, str]] | None,
+        json: object | None,
     ) -> TransportResponse:
         """Return a response selected by the request path."""
         del data, files
@@ -89,9 +89,13 @@ class ScreenTransportStub:
                         "languages": ["python"],
                     },
                 ],
+                status=HTTPStatus.OK,
             )
         if url.endswith("/campaigns/7/actions/send"):
-            return _response({"id": 11, "test_url": "https://test.example"})
+            return _response(
+                {"id": 11, "test_url": "https://test.example"},
+                status=HTTPStatus.OK,
+            )
         if url.endswith("/tests"):
             return _response(
                 {
@@ -104,6 +108,7 @@ class ScreenTransportStub:
                         "next_start": 1,
                     },
                 },
+                status=HTTPStatus.OK,
             )
         if url.endswith("/tests/11/report"):
             return TransportResponse(
@@ -112,9 +117,11 @@ class ScreenTransportStub:
                 content=b"%PDF report",
             )
         if url.endswith("/tests/11"):
-            return _response(_TEST)
+            return _response(_TEST, status=HTTPStatus.OK)
         if url.endswith("/webhook") and method == "GET":
-            return _response({"url": "https://example.com/hook"})
+            return _response(
+                {"url": "https://example.com/hook"}, status=HTTPStatus.OK
+            )
         return TransportResponse(
             status_code=HTTPStatus.NO_CONTENT,
             headers={},
@@ -126,7 +133,7 @@ def _response(
     value: object,
     /,
     *,
-    status: HTTPStatus = HTTPStatus.OK,  # noqa: NOD001
+    status: HTTPStatus,
 ) -> TransportResponse:
     """Create a JSON transport response."""
     return TransportResponse(
@@ -140,7 +147,7 @@ def _client(
     transport: ScreenTransportStub,
     /,
     *,
-    base_url: str = SCREEN_EU_BASE_URL,  # noqa: NOD001
+    base_url: str,
 ) -> CoderPad:
     """Create a client using the recording transport."""
     return CoderPad(
@@ -153,8 +160,8 @@ def _client(
 
 def test_campaigns_and_invitation() -> None:
     """Campaigns and invitations use Screen authentication and JSON."""
-    transport = ScreenTransportStub()
-    client = _client(transport)
+    transport = ScreenTransportStub(error=False)
+    client = _client(transport, base_url=SCREEN_EU_BASE_URL)
     campaigns = client.screen.campaigns.list()
     invitation = ScreenInvitation(candidate_email="ada@example.com")
     result = client.screen.campaigns.send_invitation(
@@ -189,8 +196,8 @@ def test_malformed_optional_values_use_defaults() -> None:
 
 def test_tests_filters_pagination_and_decoding() -> None:
     """Test list filters, pagination, and nested models are preserved."""
-    transport = ScreenTransportStub()
-    page = _client(transport).screen.tests.list(
+    transport = ScreenTransportStub(error=False)
+    page = _client(transport, base_url=SCREEN_EU_BASE_URL).screen.tests.list(
         campaign_id=7,
         status="completed",
         tag="python",
@@ -244,8 +251,8 @@ def test_tests_filters_pagination_and_decoding() -> None:
 
 def test_get_actions_report_and_webhook() -> None:
     """Test retrieval, mutations, PDF bytes, and webhook operations."""
-    transport = ScreenTransportStub()
-    screen = _client(transport).screen
+    transport = ScreenTransportStub(error=False)
+    screen = _client(transport, base_url=SCREEN_EU_BASE_URL).screen
     test = screen.tests.get(test_id=11, with_community_stats=True)
     screen.tests.cancel(test_id=11)
     screen.tests.resend(test_id=11)
@@ -268,4 +275,6 @@ def test_get_actions_report_and_webhook() -> None:
 def test_screen_errors_use_existing_hierarchy() -> None:
     """Screen HTTP failures map to the shared exception hierarchy."""
     with pytest.raises(expected_exception=AuthenticationError):
-        _client(ScreenTransportStub(error=True)).screen.campaigns.list()
+        _client(
+            ScreenTransportStub(error=True), base_url=SCREEN_EU_BASE_URL
+        ).screen.campaigns.list()


### PR DESCRIPTION
Supersedes the earlier collapse-only approach.

I had said 58 of these could not be removed, because the test transports implement `Transport` / `JSONTransport`, which declared `params`, `data`, `files` and `json` as optional — an implementation must be at least as permissive as its protocol.

The missing step was to remove the defaults from the protocols too.

That direction is safe and strictly more permissive for third parties: an implementation that keeps its own defaults still satisfies a protocol declared without them.

### Details

- The four `Protocol` classes in `transports.py` lose their defaults.
- The concrete `HTTPXTransport` / `AsyncHTTPXTransport` keep `json` optional, because they serve the non-JSON `Transport` protocol as well, where `json` is never passed. They are public, so `private_only` does not flag them.
- The internal call sites in `screen.py` and `async_screen.py` now pass `data` and `files` explicitly.

**No `NOD001` suppressions remain in `tests/`.** The 11 in `src/` are a separate matter and are untouched here.

180 tests pass, mypy clean, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Typing and test-only signature alignment; runtime behavior unchanged aside from explicit None for form/file args on Screen requests.
> 
> **Overview**
> **Transport protocols** (`Transport`, `JSONTransport`, and async variants) no longer use default values on `params`, `data`, `files`, or `json`. Implementations can still supply their own defaults; the protocol is stricter only in what it *requires* callers to accept, which is more permissive for third-party transports.
> 
> **Screen JSON calls** in `screen.py` and `async_screen.py` now pass `data=None` and `files=None` explicitly when invoking the transport. Public `HTTPXTransport` / `AsyncHTTPXTransport` keep an optional `json` default so they remain usable for the non-JSON transport surface.
> 
> **Tests** drop all `NOD001` suppressions: stub transports match the updated signatures, Screen helpers require explicit `error` and `status` (and `_client` requires `base_url`), with no behavioral change to runtime HTTP handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77f07c709586e32a42e3de5ed06216ae0815f50b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->