### PR TITLE
Remove the remaining defaults instead of suppressing them

### DIFF
--- a/src/coderpad/async_client.py
+++ b/src/coderpad/async_client.py
@@ -58,14 +58,14 @@ class _AsyncNamespace:
         self.base_url = base_url
         self.headers = headers
 
-    async def _request(  # noqa: NOD001
+    async def _request(
         self,
         *,
         method: str,
         url: str,
-        params: dict[str, str | int] | None = None,
-        data: dict[str, str] | None = None,
-        files: (dict[str, tuple[str, bytes, str]] | None) = None,
+        params: dict[str, str | int] | None,
+        data: dict[str, str] | None,
+        files: (dict[str, tuple[str, bytes, str]] | None),
     ) -> TransportResponse:
         """Make an async HTTP request.
 
@@ -124,6 +124,8 @@ class AsyncPadsNamespace(_AsyncNamespace):
             method="GET",
             url="/api/pads/",
             params=params,
+            data=None,
+            files=None,
         )
         data = response.json()
         return PaginatedList(
@@ -172,6 +174,8 @@ class AsyncPadsNamespace(_AsyncNamespace):
             method="POST",
             url="/api/pads/",
             data=data,
+            params=None,
+            files=None,
         )
         return Pad.from_dict(data=response.json())
 
@@ -187,6 +191,9 @@ class AsyncPadsNamespace(_AsyncNamespace):
         response = await self._request(
             method="GET",
             url=f"/api/pads/{pad_id}",
+            params=None,
+            data=None,
+            files=None,
         )
         return Pad.from_dict(data=response.json())
 
@@ -232,6 +239,8 @@ class AsyncPadsNamespace(_AsyncNamespace):
             method="PUT",
             url=f"/api/pads/{pad_id}",
             data=data,
+            params=None,
+            files=None,
         )
 
     async def get_events(
@@ -261,6 +270,8 @@ class AsyncPadsNamespace(_AsyncNamespace):
             method="GET",
             url=f"/api/pads/{pad_id}/events",
             params=params,
+            data=None,
+            files=None,
         )
         data = response.json()
         return PaginatedList(
@@ -285,6 +296,9 @@ class AsyncPadsNamespace(_AsyncNamespace):
         response = await self._request(
             method="GET",
             url=f"/api/pad_environments/{environment_id}",
+            params=None,
+            data=None,
+            files=None,
         )
         return PadEnvironment.from_dict(
             data=response.json(),
@@ -349,6 +363,8 @@ class AsyncQuestionsNamespace(_AsyncNamespace):
             method="GET",
             url="/api/questions/",
             params=params,
+            data=None,
+            files=None,
         )
         data = response.json()
         return PaginatedList(
@@ -443,6 +459,7 @@ class AsyncQuestionsNamespace(_AsyncNamespace):
             url="/api/questions/",
             data=data,
             files=files,
+            params=None,
         )
         return Question.model_validate(obj=response.json())
 
@@ -462,6 +479,9 @@ class AsyncQuestionsNamespace(_AsyncNamespace):
         response = await self._request(
             method="GET",
             url=f"/api/questions/{question_id}",
+            params=None,
+            data=None,
+            files=None,
         )
         return Question.model_validate(obj=response.json())
 
@@ -551,6 +571,7 @@ class AsyncQuestionsNamespace(_AsyncNamespace):
             url=f"/api/questions/{question_id}",
             data=data,
             files=files,
+            params=None,
         )
 
     async def delete(
@@ -566,6 +587,9 @@ class AsyncQuestionsNamespace(_AsyncNamespace):
         await self._request(
             method="DELETE",
             url=f"/api/questions/{question_id}",
+            params=None,
+            data=None,
+            files=None,
         )
 
 
@@ -597,6 +621,8 @@ class AsyncOrganizationPadsNamespace(_AsyncNamespace):
             method="GET",
             url="/api/organization/pads",
             params=params,
+            data=None,
+            files=None,
         )
         data = response.json()
         return PaginatedList(
@@ -639,6 +665,8 @@ class AsyncOrganizationQuestionsNamespace(
             method="GET",
             url="/api/organization/questions",
             params=params,
+            data=None,
+            files=None,
         )
         data = response.json()
         return PaginatedList(
@@ -672,6 +700,8 @@ class AsyncOrganizationUsersNamespace(_AsyncNamespace):
             method="GET",
             url="/api/organization/users",
             params=params,
+            data=None,
+            files=None,
         )
         return [
             OrganizationUser.model_validate(obj=item)
@@ -733,6 +763,9 @@ class AsyncOrganizationNamespace(_AsyncNamespace):
         response = await self._request(
             method="GET",
             url="/api/organization",
+            params=None,
+            data=None,
+            files=None,
         )
         return Organization.from_dict(
             data=response.json(),
@@ -763,6 +796,8 @@ class AsyncOrganizationNamespace(_AsyncNamespace):
             method="GET",
             url="/api/organization/stats",
             params=params,
+            data=None,
+            files=None,
         )
         return OrganizationStats.from_dict(
             data=response.json(),
@@ -777,6 +812,9 @@ class AsyncOrganizationNamespace(_AsyncNamespace):
         response = await self._request(
             method="GET",
             url="/api/quota",
+            params=None,
+            data=None,
+            files=None,
         )
         return Quota.model_validate(obj=response.json())
 

--- a/src/coderpad/async_screen.py
+++ b/src/coderpad/async_screen.py
@@ -29,20 +29,20 @@ class _AsyncScreenNamespace:
         *,
         transport: AsyncJSONTransport,
         api_key: str,
-        base_url: str = SCREEN_US_BASE_URL,  # noqa: NOD001
+        base_url: str,
     ) -> None:
         """Create shared asynchronous Screen request state."""
         self.transport: AsyncJSONTransport = transport
         self.base_url: str = base_url.rstrip("/")
         self.headers: dict[str, str] = {"API-Key": api_key}
 
-    async def _request(  # noqa: NOD001
+    async def _request(
         self,
         *,
         method: str,
         path: str,
-        params: dict[str, str | int] | None = None,
-        json: object | None = None,
+        params: dict[str, str | int] | None,
+        json: object | None,
     ) -> TransportResponse:
         """Make a Screen request and map HTTP failures."""
         response = await self.transport(
@@ -65,7 +65,9 @@ class AsyncScreenCampaignsNamespace(_AsyncScreenNamespace):
 
     async def list(self) -> builtins.list[ScreenCampaign]:
         """List assessment campaigns."""
-        response = await self._request(method="GET", path="/campaigns")
+        response = await self._request(
+            method="GET", path="/campaigns", params=None, json=None
+        )
         raw_campaigns: object = response.json()
         return ScreenCampaign.list_from_value(value=raw_campaigns)
 
@@ -80,6 +82,7 @@ class AsyncScreenCampaignsNamespace(_AsyncScreenNamespace):
             method="POST",
             path=f"/campaigns/{campaign_id}/actions/send",
             json=invitation.model_dump(exclude_none=True),
+            params=None,
         )
         return ScreenInvitationResult.from_dict(data=response.json())
 
@@ -127,6 +130,7 @@ class AsyncScreenTestsNamespace(_AsyncScreenNamespace):
             method="GET",
             path="/tests",
             params=params,
+            json=None,
         )
         return ScreenTestsPage.from_dict(data=response.json())
 
@@ -144,6 +148,7 @@ class AsyncScreenTestsNamespace(_AsyncScreenNamespace):
             method="GET",
             path=f"/tests/{test_id}",
             params=params,
+            json=None,
         )
         return ScreenTest.from_dict(data=response.json())
 
@@ -152,6 +157,8 @@ class AsyncScreenTestsNamespace(_AsyncScreenNamespace):
         await self._request(
             method="POST",
             path=f"/tests/{test_id}/actions/cancel",
+            params=None,
+            json=None,
         )
 
     async def resend(self, *, test_id: int) -> None:
@@ -159,11 +166,15 @@ class AsyncScreenTestsNamespace(_AsyncScreenNamespace):
         await self._request(
             method="POST",
             path=f"/tests/{test_id}/actions/resend",
+            params=None,
+            json=None,
         )
 
     async def delete(self, *, test_id: int) -> None:
         """Delete a test session."""
-        await self._request(method="DELETE", path=f"/tests/{test_id}")
+        await self._request(
+            method="DELETE", path=f"/tests/{test_id}", params=None, json=None
+        )
 
     async def report(
         self,
@@ -191,6 +202,7 @@ class AsyncScreenTestsNamespace(_AsyncScreenNamespace):
             method="GET",
             path=f"/tests/{test_id}/report",
             params=params,
+            json=None,
         )
         return response.content
 
@@ -201,16 +213,22 @@ class AsyncScreenWebhookNamespace(_AsyncScreenNamespace):
 
     async def get(self) -> ScreenWebhook:
         """Retrieve webhook configuration."""
-        response = await self._request(method="GET", path="/webhook")
+        response = await self._request(
+            method="GET", path="/webhook", params=None, json=None
+        )
         return ScreenWebhook.from_dict(data=response.json())
 
     async def set(self, *, url: str) -> None:
         """Set or replace the webhook URL."""
-        await self._request(method="POST", path="/webhook", json=url)
+        await self._request(
+            method="POST", path="/webhook", json=url, params=None
+        )
 
     async def delete(self) -> None:
         """Delete the webhook configuration."""
-        await self._request(method="DELETE", path="/webhook")
+        await self._request(
+            method="DELETE", path="/webhook", params=None, json=None
+        )
 
 
 @beartype

--- a/src/coderpad/client.py
+++ b/src/coderpad/client.py
@@ -57,14 +57,14 @@ class _Namespace:
         self.base_url = base_url
         self.headers = headers
 
-    def _request(  # noqa: NOD001
+    def _request(
         self,
         *,
         method: str,
         url: str,
-        params: dict[str, str | int] | None = None,
-        data: dict[str, str] | None = None,
-        files: (dict[str, tuple[str, bytes, str]] | None) = None,
+        params: dict[str, str | int] | None,
+        data: dict[str, str] | None,
+        files: (dict[str, tuple[str, bytes, str]] | None),
     ) -> TransportResponse:
         """Make an HTTP request.
 
@@ -123,6 +123,8 @@ class PadsNamespace(_Namespace):
             method="GET",
             url="/api/pads/",
             params=params,
+            data=None,
+            files=None,
         )
         data = response.json()
         return PaginatedList(
@@ -171,6 +173,8 @@ class PadsNamespace(_Namespace):
             method="POST",
             url="/api/pads/",
             data=data,
+            params=None,
+            files=None,
         )
         return Pad.from_dict(data=response.json())
 
@@ -186,6 +190,9 @@ class PadsNamespace(_Namespace):
         response = self._request(
             method="GET",
             url=f"/api/pads/{pad_id}",
+            params=None,
+            data=None,
+            files=None,
         )
         return Pad.from_dict(data=response.json())
 
@@ -231,6 +238,8 @@ class PadsNamespace(_Namespace):
             method="PUT",
             url=f"/api/pads/{pad_id}",
             data=data,
+            params=None,
+            files=None,
         )
 
     def get_events(
@@ -259,6 +268,8 @@ class PadsNamespace(_Namespace):
             method="GET",
             url=f"/api/pads/{pad_id}/events",
             params=params,
+            data=None,
+            files=None,
         )
         data = response.json()
         return PaginatedList(
@@ -283,6 +294,9 @@ class PadsNamespace(_Namespace):
         response = self._request(
             method="GET",
             url=f"/api/pad_environments/{environment_id}",
+            params=None,
+            data=None,
+            files=None,
         )
         return PadEnvironment.from_dict(
             data=response.json(),
@@ -346,6 +360,8 @@ class QuestionsNamespace(_Namespace):
             method="GET",
             url="/api/questions/",
             params=params,
+            data=None,
+            files=None,
         )
         data = response.json()
         return PaginatedList(
@@ -439,6 +455,7 @@ class QuestionsNamespace(_Namespace):
             url="/api/questions/",
             data=data,
             files=files,
+            params=None,
         )
         return Question.model_validate(obj=response.json())
 
@@ -458,6 +475,9 @@ class QuestionsNamespace(_Namespace):
         response = self._request(
             method="GET",
             url=f"/api/questions/{question_id}",
+            params=None,
+            data=None,
+            files=None,
         )
         return Question.model_validate(obj=response.json())
 
@@ -547,6 +567,7 @@ class QuestionsNamespace(_Namespace):
             url=f"/api/questions/{question_id}",
             data=data,
             files=files,
+            params=None,
         )
 
     def delete(
@@ -562,6 +583,9 @@ class QuestionsNamespace(_Namespace):
         self._request(
             method="DELETE",
             url=f"/api/questions/{question_id}",
+            params=None,
+            data=None,
+            files=None,
         )
 
 
@@ -593,6 +617,8 @@ class OrganizationPadsNamespace(_Namespace):
             method="GET",
             url="/api/organization/pads",
             params=params,
+            data=None,
+            files=None,
         )
         data = response.json()
         return PaginatedList(
@@ -630,6 +656,8 @@ class OrganizationQuestionsNamespace(_Namespace):
             method="GET",
             url="/api/organization/questions",
             params=params,
+            data=None,
+            files=None,
         )
         data = response.json()
         return PaginatedList(
@@ -663,6 +691,8 @@ class OrganizationUsersNamespace(_Namespace):
             method="GET",
             url="/api/organization/users",
             params=params,
+            data=None,
+            files=None,
         )
         return [
             OrganizationUser.model_validate(obj=item)
@@ -720,6 +750,9 @@ class OrganizationNamespace(_Namespace):
         response = self._request(
             method="GET",
             url="/api/organization",
+            params=None,
+            data=None,
+            files=None,
         )
         return Organization.from_dict(
             data=response.json(),
@@ -749,6 +782,8 @@ class OrganizationNamespace(_Namespace):
             method="GET",
             url="/api/organization/stats",
             params=params,
+            data=None,
+            files=None,
         )
         return OrganizationStats.from_dict(
             data=response.json(),
@@ -763,6 +798,9 @@ class OrganizationNamespace(_Namespace):
         response = self._request(
             method="GET",
             url="/api/quota",
+            params=None,
+            data=None,
+            files=None,
         )
         return Quota.model_validate(obj=response.json())
 

--- a/src/coderpad/screen.py
+++ b/src/coderpad/screen.py
@@ -37,13 +37,13 @@ class _ScreenNamespace:
         self.base_url: str = base_url.rstrip("/")
         self.headers: dict[str, str] = {"API-Key": api_key}
 
-    def _request(  # noqa: NOD001
+    def _request(
         self,
         *,
         method: str,
         path: str,
-        params: dict[str, str | int] | None = None,
-        json: object | None = None,
+        params: dict[str, str | int] | None,
+        json: object | None,
     ) -> TransportResponse:
         """Make a Screen request and map HTTP failures."""
         response = self.transport(
@@ -66,7 +66,9 @@ class ScreenCampaignsNamespace(_ScreenNamespace):
 
     def list(self) -> builtins.list[ScreenCampaign]:
         """List assessment campaigns."""
-        response = self._request(method="GET", path="/campaigns")
+        response = self._request(
+            method="GET", path="/campaigns", params=None, json=None
+        )
         raw_campaigns: object = response.json()
         return ScreenCampaign.list_from_value(value=raw_campaigns)
 
@@ -81,6 +83,7 @@ class ScreenCampaignsNamespace(_ScreenNamespace):
             method="POST",
             path=f"/campaigns/{campaign_id}/actions/send",
             json=invitation.model_dump(exclude_none=True),
+            params=None,
         )
         return ScreenInvitationResult.from_dict(data=response.json())
 
@@ -124,7 +127,9 @@ class ScreenTestsNamespace(_ScreenNamespace):
         params.update(
             (key, value) for key, value in values if value is not None
         )
-        response = self._request(method="GET", path="/tests", params=params)
+        response = self._request(
+            method="GET", path="/tests", params=params, json=None
+        )
         return ScreenTestsPage.from_dict(data=response.json())
 
     def get(
@@ -141,20 +146,33 @@ class ScreenTestsNamespace(_ScreenNamespace):
             method="GET",
             path=f"/tests/{test_id}",
             params=params,
+            json=None,
         )
         return ScreenTest.from_dict(data=response.json())
 
     def cancel(self, *, test_id: int) -> None:
         """Cancel a test invitation."""
-        self._request(method="POST", path=f"/tests/{test_id}/actions/cancel")
+        self._request(
+            method="POST",
+            path=f"/tests/{test_id}/actions/cancel",
+            params=None,
+            json=None,
+        )
 
     def resend(self, *, test_id: int) -> None:
         """Resend a test invitation."""
-        self._request(method="POST", path=f"/tests/{test_id}/actions/resend")
+        self._request(
+            method="POST",
+            path=f"/tests/{test_id}/actions/resend",
+            params=None,
+            json=None,
+        )
 
     def delete(self, *, test_id: int) -> None:
         """Delete a test session."""
-        self._request(method="DELETE", path=f"/tests/{test_id}")
+        self._request(
+            method="DELETE", path=f"/tests/{test_id}", params=None, json=None
+        )
 
     def report(
         self,
@@ -182,6 +200,7 @@ class ScreenTestsNamespace(_ScreenNamespace):
             method="GET",
             path=f"/tests/{test_id}/report",
             params=params,
+            json=None,
         ).content
 
 
@@ -191,16 +210,18 @@ class ScreenWebhookNamespace(_ScreenNamespace):
 
     def get(self) -> ScreenWebhook:
         """Retrieve webhook configuration."""
-        response = self._request(method="GET", path="/webhook")
+        response = self._request(
+            method="GET", path="/webhook", params=None, json=None
+        )
         return ScreenWebhook.from_dict(data=response.json())
 
     def set(self, *, url: str) -> None:
         """Set or replace the webhook URL."""
-        self._request(method="POST", path="/webhook", json=url)
+        self._request(method="POST", path="/webhook", json=url, params=None)
 
     def delete(self) -> None:
         """Delete the webhook configuration."""
-        self._request(method="DELETE", path="/webhook")
+        self._request(method="DELETE", path="/webhook", params=None, json=None)
 
 
 @beartype


### PR DESCRIPTION
Removes the last five `NOD001` suppressions by removing the defaults for real.\n\n`_request` and the Screen namespace constructor are module-private, so requiring their arguments is not an API change. 110 call sites updated.\n\nWorth noting the two `_request` methods have different signatures — `client.py` takes `params`/`data`/`files`, `screen.py` takes `params`/`json` — so the update is per-file rather than matched on the bare name.\n\n**5 → 0.** mypy clean, ruff clean, 180 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal-only signature and call-site updates; public client APIs are unchanged and tests reportedly still pass.
> 
> **Overview**
> Removes optional defaults on module-private **`_request`** helpers (and on **`_AsyncScreenNamespace`**’s `base_url`) so callers must pass every argument explicitly, eliminating the last **`NOD001`** noqa suppressions.
> 
> Interview clients (`client.py`, `async_client.py`) now pass **`params` / `data` / `files`** (often `None`) at each **`_request`** call; Screen sync/async namespaces do the same for **`params` / `json`**. Runtime HTTP behavior is unchanged—only signatures and call sites are stricter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8a29afff6721c60fc5077ca044451c8af3980bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->