### PR TITLE
Bump beartype to 0.23.0rc0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,13 +33,13 @@ dynamic = [
     "version",
 ]
 dependencies = [
-    "beartype>=0.22.9",
+    "beartype==0.23.0rc0",
     "httpx>=0.28.0",
     "pydantic>=2.12.0",
 ]
 optional-dependencies.dev = [
     "actionlint-py==1.7.12.24",
-    "beartype==0.22.9",
+    "beartype==0.23.0rc0",
     "check-manifest==0.51",
     "deptry==0.25.1",
     "doc8==2.0.0",


### PR DESCRIPTION
Tests the [beartype 0.23.0rc0](https://pypi.org/project/beartype/0.23.0rc0/) release candidate against this repository's test suite.

Pins `beartype` to the release candidate in `pyproject.toml` and updates `uv.lock` to match.

Not intended to merge as-is — the pin should be relaxed once the release candidate has been evaluated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only pin with no source changes; risk is limited to possible RC behavior differences in runtime type checking during tests.
> 
> **Overview**
> Pins **beartype** to **`0.23.0rc0`** in `pyproject.toml` so CI and local dev exercise the upcoming release against this repo’s tests (including **`pytest-beartype-tests`**).
> 
> The change replaces the previous **`>=0.22.9`** runtime constraint and matching **`0.22.9`** dev extra with an exact RC pin in both places. It is meant as a temporary evaluation branch, not a permanent dependency policy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e6e8e75b4dc47d94877ca9101e5ecd0c59baa3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->